### PR TITLE
Fix money coercion with non-commutative operations

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -13,6 +13,10 @@ class Money
     @cents = (@value * 100).to_i
   end
 
+  def -@
+    Money.new(-value)
+  end
+
   def <=>(other)
     cents <=> other.to_money.cents
   end
@@ -45,9 +49,31 @@ class Money
     self.class == other.class && value == other.value
   end
 
+  class ReverseOperationProxy
+    def initialize(value)
+      @value = value
+    end
+
+    def <=>(other)
+      -(other <=> @value)
+    end
+
+    def +(other)
+      other + @value
+    end
+
+    def -(other)
+      -(other - @value)
+    end
+
+    def *(other)
+      other * @value
+    end
+  end
+
   def coerce(other)
     raise TypeError, "Money can't be coerced into #{other.class}" unless other.is_a?(Numeric)
-    [self, other]
+    [ReverseOperationProxy.new(other), self]
   end
 
   def hash

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -76,6 +76,16 @@ describe "Money" do
     (1.50 + Money.new(1.33)).should == Money.new(2.83)
   end
 
+  it "should be subtractable with integer" do
+    (Money.new(1.66) - 1).should == Money.new(0.66)
+    (2 - Money.new(1.66)).should == Money.new(0.34)
+  end
+
+  it "should be subtractable with float" do
+    (Money.new(1.66) - 1.50).should == Money.new(0.16)
+    (1.50 - Money.new(1.33)).should == Money.new(0.17)
+  end
+
   it "should be multipliable with an integer" do
     (Money.new(1.00) * 55).should == Money.new(55.00)
     (55 * Money.new(1.00)).should == Money.new(55.00)
@@ -185,6 +195,9 @@ describe "Money" do
       (@money <=> 1).should == 0
       (@money <=> 2).should == -1
       (@money <=> 0.5).should == 1
+      (1 <=> @money).should == 0
+      (2 <=> @money).should == 1
+      (0.5 <=> @money).should == -1
     end
 
     it "should have the same hash value as $1" do


### PR DESCRIPTION
`coerce` used to just flip the order of the operands and retry the operation. It worked fine with addition and multiplication, but gave the negated result for subtraction.
