### PR TITLE
Revert "Merge pull request #14 from Shopify/bankers_rounding"

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -142,6 +142,10 @@ class Money
     Money.new(value.floor)
   end
 
+  def round(ndigits=0)
+    Money.new(value.round(ndigits))
+  end
+
   def fraction(rate)
     raise ArgumentError, "rate should be positive" if rate < 0
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -9,7 +9,7 @@ class Money
   def initialize(value = 0)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
 
-    @value = value_to_decimal(value).round(2, :banker)
+    @value = value_to_decimal(value).round(2)
     @cents = (@value * 100).to_i
   end
 
@@ -140,10 +140,6 @@ class Money
 
   def floor
     Money.new(value.floor)
-  end
-
-  def round(*args)
-    Money.new(value.round(*args))
   end
 
   def fraction(rate)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -166,15 +166,6 @@ describe "Money" do
     Money.new(21).floor.should == Money.new(21)
   end
 
-  it "should support round with number of fractional digits and mode similar to BigDecimal" do
-    Money.new(15.25).round(0, :banker).should == Money.new(15)
-    Money.new(15.5).round(0, :banker).should == Money.new(16)
-    Money.new(15.55).round(0, :banker).should == Money.new(16)
-    Money.new(16.5).round(0, :banker).should == Money.new(16)
-    Money.new(16.51).round(0, :banker).should == Money.new(17)
-    Money.new(16.51).round(1).should == Money.new(16.5)
-  end
-
   describe "frozen with amount of $1" do
     before(:each) do
       @money = Money.new(1.00).freeze
@@ -340,15 +331,13 @@ describe "Money" do
     end
   end
 
-  describe "created with 3 decimal places" do
-    it "should round 3rd decimal place to nearest even neighbour" do
-      Money.new(1.124).value.should == BigDecimal.new("1.12")
-      Money.new(1.125).value.should == BigDecimal.new("1.12")
-      Money.new(1.126).value.should == BigDecimal.new("1.13")
+  describe "with amount of $1 with created with 3 decimal places" do
+    before(:each) do
+      @money = Money.new(1.125)
+    end
 
-      Money.new(1.134).value.should == BigDecimal.new("1.13")
-      Money.new(1.135).value.should == BigDecimal.new("1.14")
-      Money.new(1.136).value.should == BigDecimal.new("1.14")
+    it "should round 3rd decimal place" do
+      @money.value.should == BigDecimal.new("1.13")
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -362,4 +362,27 @@ describe "Money" do
       Money.parser = nil # reset
     end
   end
+  
+  describe "round" do
+    
+    it "should round to 0 decimal places by default" do
+      Money.new(54.1).round.should == Money.new(54)
+      Money.new(54.5).round.should == Money.new(55)
+    end
+    
+    # Overview of standard vs. banker's rounding for next 4 specs:
+    # http://www.xbeat.net/vbspeed/i_BankersRounding.htm
+    it "should implement standard rounding for 2 digits" do
+      Money.new(54.1754).round(2).should == Money.new(54.18)
+      Money.new(343.2050).round(2).should == Money.new(343.21)
+      Money.new(106.2038).round(2).should == Money.new(106.20)
+    end
+
+    it "should implement standard rounding for 1 digit" do
+      Money.new(27.25).round(1).should == Money.new(27.3)
+      Money.new(27.45).round(1).should == Money.new(27.5)
+      Money.new(27.55).round(1).should == Money.new(27.6)
+    end
+
+  end
 end


### PR DESCRIPTION
This reverts commit 61de47c004d7e4704731d85fae5fabb23ec86dc4, reversing
changes made to 8c24f677185303eaef119222040233d6b1fd0141.

@boourns @jeromecornet @Smcchoi @mikeygagnon 

Banker's rounding has no place at all in the money library. I was going to leave the option in there and change the default, but it really shouldn't be a feature at all. Shopify will need to stop using the `:banker` option before we merge this in.