### PR TITLE
Update RSpec to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem 'rdoc'
-  gem "rspec", "~> 2.4.0"
+  gem "rspec", "~> 3.2.0"
   gem "bundler", "~> 1.5"
   gem "jeweler", "~> 1.6.0"
   gem "simplecov", ">= 0"


### PR DESCRIPTION
This allows to use the newer syntax such as `expect(foo).to eq(bar)` as well as a better runner.

r: @gmalette @davidcornu  