### PR TITLE
Add a non-ActiveRecord money accessor

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -2,4 +2,5 @@ require File.dirname(__FILE__) + '/money/money'
 require File.dirname(__FILE__) + '/money/money_parser'
 require File.dirname(__FILE__) + '/money/accounting_money_parser'
 require File.dirname(__FILE__) + '/money/core_extensions'
+require File.dirname(__FILE__) + '/money_accessor'
 require File.dirname(__FILE__) + '/money_column' if defined?(Rails)

--- a/lib/money_accessor.rb
+++ b/lib/money_accessor.rb
@@ -1,0 +1,27 @@
+module MoneyAccessor
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def money_accessor(*columns)
+      Array(columns).flatten.each do |name|
+        define_method(name) do
+          value = instance_variable_get("@#{name}")
+          value.blank? ? nil : Money.new(value)
+        end
+
+        define_method("#{name}=") do |value|
+          if value.blank? || !value.respond_to?(:to_money)
+            instance_variable_set("@#{name}", nil)
+            nil
+          else
+            money = value.to_money
+            instance_variable_set("@#{name}", money.value)
+            money
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -2,14 +2,14 @@ module MoneyColumn
   module ActiveRecordHooks
     def self.included(base)
       base.extend(ClassMethods)
-    end                   
+    end
 
     module ClassMethods
       def money_column(*columns)
-        [columns].flatten.each do |name|
+        Array(columns).flatten.each do |name|
           define_method(name) do
             value = read_attribute(name)
-            value.blank? ? nil : Money.new(read_attribute(name))
+            value.blank? ? nil : Money.new(value)
           end
 
           define_method("#{name}_before_type_cast") do
@@ -31,4 +31,3 @@ module MoneyColumn
     end
   end
 end
-

--- a/spec/money_accessor_spec.rb
+++ b/spec/money_accessor_spec.rb
@@ -1,0 +1,71 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+class NormalObject
+  include MoneyAccessor
+
+  money_accessor :price
+
+  def initialize(price)
+    @price = price
+  end
+end
+
+describe NormalObject do
+  before(:each) do 
+    @object = Object.new
+    @money = Money.new("1.00")
+  end
+
+  it "generates an attribute reader that returns a money object" do
+    object = NormalObject.new(100)
+
+    expect(object.price).to eq(Money.new(100))
+  end
+
+  it "generates an attribute reader that returns a nil object if the value was nil" do
+    object = NormalObject.new(nil)
+
+    expect(object.price).to eq(nil)
+  end
+
+  it "generates an attribute reader that returns a nil object if the value was blank" do
+    object = NormalObject.new('')
+
+    expect(object.price).to eq(nil)
+  end
+
+  it "generates an attribute weitter that allow setting a money object" do
+    object = NormalObject.new(0)
+    object.price = Money.new(10)
+
+    expect(object.price).to eq(Money.new(10))
+  end
+
+  it "generates an attribute weitter that allow setting a integer value" do
+    object = NormalObject.new(0)
+    object.price = 10
+
+    expect(object.price).to eq(Money.new(10))
+  end
+
+  it "generates an attribute weitter that allow setting a float value" do
+    object = NormalObject.new(0)
+    object.price = 10.12
+
+    expect(object.price).to eq(Money.new(10.12))
+  end
+
+  it "generates an attribute weitter that allow setting a nil value" do
+    object = NormalObject.new(0)
+    object.price = nil
+
+    expect(object.price).to eq(nil)
+  end
+
+  it "generates an attribute weitter that allow setting a blank value" do
+    object = NormalObject.new(0)
+    object.price = ''
+
+    expect(object.price).to eq(nil)
+  end
+end


### PR DESCRIPTION
Proposing a new module to support the equivalent of `MoneyColumn::ActiveRecordHooks` for non `ActiveRecord::Base` objects.

```ruby
class NormalObject
  include MoneyAccessor
  
  money_accessor :price

  def initialize(price)
    @price = price
  end
end

object = NormalObject.new(12.34)
object.price # => #<Money value:12.34>
```

The code is somewhat similar to `MoneyColumn::ActiveRecordHooks`, but I believe there was not enough in common to abstract what would be shared. I think it would simply complexify things without any real gain.