### PR TITLE
Cleanup deprecated rspec expectation format

### DIFF
--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -7,95 +7,95 @@ describe AccountingMoneyParser do
     end
     
     it "should parse parenthesis as a negative amount eg (99.00)" do
-      @parser.parse("(99.00)").should == Money.new(-99.00)
+      expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00))
     end
   
     it "should parse parenthesis as a negative amount regardless of currency sign" do
-      @parser.parse("($99.00)").should == Money.new(-99.00)
+      expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00))
     end
   
     it "should parse an empty string to $0" do
-      @parser.parse("").should == Money.new
+      expect(@parser.parse("")).to eq(Money.new)
     end
   
     it "should parse an invalid string to $0" do
-      @parser.parse("no money").should == Money.new
+      expect(@parser.parse("no money")).to eq(Money.new)
     end
   
     it "should parse a single digit integer string" do
-      @parser.parse("1").should == Money.new(1.00)
+      expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
   
     it "should parse a double digit integer string" do
-      @parser.parse("10").should == Money.new(10.00)
+      expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
   
     it "should parse an integer string amount with a leading $" do
-      @parser.parse("$1").should == Money.new(1.00)
+      expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
   
     it "should parse a float string amount" do
-      @parser.parse("1.37").should == Money.new(1.37)
+      expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
   
     it "should parse a float string amount with a leading $" do
-      @parser.parse("$1.37").should == Money.new(1.37)
+      expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
   
     it "should parse a float string with a single digit after the decimal" do
-      @parser.parse("10.0").should == Money.new(10.00)
+      expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
   
     it "should parse a float string with two digits after the decimal" do
-      @parser.parse("10.00").should == Money.new(10.00)
+      expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
   
     it "should parse the amount from an amount surrounded by whitespace and garbage" do
-      @parser.parse("Rubbish $1.00 Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse the amount from an amount surrounded by garbage" do
-      @parser.parse("Rubbish$1.00Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse a negative integer amount in the hundreds" do
-      @parser.parse("-100").should == Money.new(-100.00)
+      expect(@parser.parse("-100")).to eq(Money.new(-100.00))
     end
 
     it "should parse an integer amount in the hundreds" do
-      @parser.parse("410").should == Money.new(410.00)
+      expect(@parser.parse("410")).to eq(Money.new(410.00))
     end
 
     it "should parse a positive amount with a thousands separator" do
-      @parser.parse("100,000.00").should == Money.new(100_000.00)
+      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
   
     it "should parse a negative amount with a thousands separator" do
-      @parser.parse("-100,000.00").should == Money.new(-100_000.00)
+      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
 
     it "should parse negative $1.00" do
-      @parser.parse("-1.00").should == Money.new(-1.00)
+      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
     end
 
     it "should parse a negative cents amount" do
-      @parser.parse("-0.90").should == Money.new(-0.90)
+      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
     
     it "should parse amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("0.123").should == Money.new(0.12)
+      expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
     
     it "should parse negative amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("-0.123").should == Money.new(-0.12)
+      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
     
     it "should parse negative amount with multiple leading - signs" do
-      @parser.parse("--0.123").should == Money.new(-0.12)
+      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
     
     it "should parse negative amount with multiple - signs" do
-      @parser.parse("--0.123--").should == Money.new(-0.12)
+      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
   end
 
@@ -105,47 +105,47 @@ describe AccountingMoneyParser do
     end
     
     it "should parse dollar amount $1,00 with leading $" do
-      @parser.parse("$1,00").should == Money.new(1.00)
+      expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
 
     it "should parse dollar amount $1,37 with leading $, and non-zero cents" do
-      @parser.parse("$1,37").should == Money.new(1.37)
+      expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
     
     it "should parse the amount from an amount surrounded by whitespace and garbage" do
-      @parser.parse("Rubbish $1,00 Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse the amount from an amount surrounded by garbage" do
-      @parser.parse("Rubbish$1,00Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
     
     it "should parse thousands amount" do
-      @parser.parse("1.000").should == Money.new(1000.00)
+      expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
     
     it "should parse negative hundreds amount" do
-      @parser.parse("-100,00").should == Money.new(-100.00)
+      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
     
     it "should parse positive hundreds amount" do
-      @parser.parse("410,00").should == Money.new(410.00)
+      expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
     
     it "should parse a positive amount with a thousands separator" do
-      @parser.parse("100.000,00").should == Money.new(100_000.00)
+      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
   
     it "should parse a negative amount with a thousands separator" do
-      @parser.parse("-100.000,00").should == Money.new(-100_000.00)
+      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
     
     it "should parse amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("0,123").should == Money.new(0.12)
+      expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
     
     it "should parse negative amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("-0,123").should == Money.new(-0.12)
+      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
   
@@ -155,47 +155,47 @@ describe AccountingMoneyParser do
     end
     
     it "should parse 50.0" do
-      @parser.parse("50.0").should == Money.new(50.00)
+      expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
     
     it "should parse 50.1" do
-      @parser.parse("50.1").should == Money.new(50.10)
+      expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
     
     it "should parse 50.2" do
-      @parser.parse("50.2").should == Money.new(50.20)
+      expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
     
     it "should parse 50.3" do
-      @parser.parse("50.3").should == Money.new(50.30)
+      expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
     
     it "should parse 50.4" do
-      @parser.parse("50.4").should == Money.new(50.40)
+      expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
     
     it "should parse 50.5" do
-      @parser.parse("50.5").should == Money.new(50.50)
+      expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
     
     it "should parse 50.6" do
-      @parser.parse("50.6").should == Money.new(50.60)
+      expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
     
     it "should parse 50.7" do
-      @parser.parse("50.7").should == Money.new(50.70)
+      expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
     
     it "should parse 50.8" do
-      @parser.parse("50.8").should == Money.new(50.80)
+      expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
     
     it "should parse 50.9" do
-      @parser.parse("50.9").should == Money.new(50.90)
+      expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
     
     it "should parse 50.10" do
-      @parser.parse("50.10").should == Money.new(50.10)
+      expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end
 end

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -6,95 +6,95 @@ describe AccountingMoneyParser do
       @parser = AccountingMoneyParser.new
     end
     
-    it "should parse parenthesis as a negative amount eg (99.00)" do
+    it "parses parenthesis as a negative amount eg (99.00)" do
       expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00))
     end
   
-    it "should parse parenthesis as a negative amount regardless of currency sign" do
+    it "parses parenthesis as a negative amount regardless of currency sign" do
       expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00))
     end
   
-    it "should parse an empty string to $0" do
+    it "parses an empty string to $0" do
       expect(@parser.parse("")).to eq(Money.new)
     end
   
-    it "should parse an invalid string to $0" do
+    it "parses an invalid string to $0" do
       expect(@parser.parse("no money")).to eq(Money.new)
     end
   
-    it "should parse a single digit integer string" do
+    it "parses a single digit integer string" do
       expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
   
-    it "should parse a double digit integer string" do
+    it "parses a double digit integer string" do
       expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
   
-    it "should parse an integer string amount with a leading $" do
+    it "parses an integer string amount with a leading $" do
       expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
   
-    it "should parse a float string amount" do
+    it "parses a float string amount" do
       expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
   
-    it "should parse a float string amount with a leading $" do
+    it "parses a float string amount with a leading $" do
       expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
   
-    it "should parse a float string with a single digit after the decimal" do
+    it "parses a float string with a single digit after the decimal" do
       expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
   
-    it "should parse a float string with two digits after the decimal" do
+    it "parses a float string with two digits after the decimal" do
       expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
   
-    it "should parse the amount from an amount surrounded by whitespace and garbage" do
+    it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse the amount from an amount surrounded by garbage" do
+    it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse a negative integer amount in the hundreds" do
+    it "parses a negative integer amount in the hundreds" do
       expect(@parser.parse("-100")).to eq(Money.new(-100.00))
     end
 
-    it "should parse an integer amount in the hundreds" do
+    it "parses an integer amount in the hundreds" do
       expect(@parser.parse("410")).to eq(Money.new(410.00))
     end
 
-    it "should parse a positive amount with a thousands separator" do
+    it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
   
-    it "should parse a negative amount with a thousands separator" do
+    it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
 
-    it "should parse negative $1.00" do
+    it "parses negative $1.00" do
       expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
     end
 
-    it "should parse a negative cents amount" do
+    it "parses a negative cents amount" do
       expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
     
-    it "should parse amount with 3 decimals and 0 dollar amount" do
+    it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
     
-    it "should parse negative amount with 3 decimals and 0 dollar amount" do
+    it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
     
-    it "should parse negative amount with multiple leading - signs" do
+    it "parses negative amount with multiple leading - signs" do
       expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
     
-    it "should parse negative amount with multiple - signs" do
+    it "parses negative amount with multiple - signs" do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
   end
@@ -104,47 +104,47 @@ describe AccountingMoneyParser do
       @parser = AccountingMoneyParser.new
     end
     
-    it "should parse dollar amount $1,00 with leading $" do
+    it "parses dollar amount $1,00 with leading $" do
       expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
 
-    it "should parse dollar amount $1,37 with leading $, and non-zero cents" do
+    it "parses dollar amount $1,37 with leading $, and non-zero cents" do
       expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
     
-    it "should parse the amount from an amount surrounded by whitespace and garbage" do
+    it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse the amount from an amount surrounded by garbage" do
+    it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
     
-    it "should parse thousands amount" do
+    it "parses thousands amount" do
       expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
     
-    it "should parse negative hundreds amount" do
+    it "parses negative hundreds amount" do
       expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
     
-    it "should parse positive hundreds amount" do
+    it "parses positive hundreds amount" do
       expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
     
-    it "should parse a positive amount with a thousands separator" do
+    it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
   
-    it "should parse a negative amount with a thousands separator" do
+    it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
     
-    it "should parse amount with 3 decimals and 0 dollar amount" do
+    it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
     
-    it "should parse negative amount with 3 decimals and 0 dollar amount" do
+    it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
@@ -154,47 +154,47 @@ describe AccountingMoneyParser do
       @parser = AccountingMoneyParser.new
     end
     
-    it "should parse 50.0" do
+    it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
     
-    it "should parse 50.1" do
+    it "parses 50.1" do
       expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
     
-    it "should parse 50.2" do
+    it "parses 50.2" do
       expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
     
-    it "should parse 50.3" do
+    it "parses 50.3" do
       expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
     
-    it "should parse 50.4" do
+    it "parses 50.4" do
       expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
     
-    it "should parse 50.5" do
+    it "parses 50.5" do
       expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
     
-    it "should parse 50.6" do
+    it "parses 50.6" do
       expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
     
-    it "should parse 50.7" do
+    it "parses 50.7" do
       expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
     
-    it "should parse 50.8" do
+    it "parses 50.8" do
       expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
     
-    it "should parse 50.9" do
+    it "parses 50.9" do
       expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
     
-    it "should parse 50.10" do
+    it "parses 50.10" do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 shared_examples_for "an object supporting to_money" do
   it "should support to_money" do
-    @value.to_money.should == @money
+    expect(@value.to_money).to eq(@money)
   end
 end
 

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 shared_examples_for "an object supporting to_money" do
-  it "should support to_money" do
+  it "supports to_money" do
     expect(@value.to_money).to eq(@money)
   end
 end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -9,30 +9,30 @@ describe "MoneyColumn" do
   it "typecasts string to money" do
     m = MoneyRecord.new(:price => "100")
 
-    m.price.should == Money.new(100)
+    expect(m.price).to eq(Money.new(100))
   end
 
   it "typecasts numeric to money" do
     m = MoneyRecord.new(:price => 100)
 
-    m.price.should == Money.new(100)
+    expect(m.price).to eq(Money.new(100))
   end
 
   it "typecasts blank to nil" do
     m = MoneyRecord.new(:price => "")
 
-    m.price.should == nil
+    expect(m.price).to eq(nil)
   end
 
   it "ypecasts invalid string to empty money" do
     m = MoneyRecord.new(:price => "magic")
 
-    m.price.should == Money.new(0)
+    expect(m.price).to eq(Money.new(0))
   end
 
   it "typecasts value that does not respond to to_money as nil" do
     m = MoneyRecord.new(:price => true)
 
-    m.price.should == nil
+    expect(m.price).to eq(nil)
   end
 end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -6,87 +6,87 @@ describe MoneyParser do
       @parser = MoneyParser.new
     end
   
-    it "should parse an empty string to $0" do
+    it "parses an empty string to $0" do
       expect(@parser.parse("")).to eq(Money.new)
     end
   
-    it "should parse an invalid string to $0" do
+    it "parses an invalid string to $0" do
       expect(@parser.parse("no money")).to eq(Money.new)
     end
   
-    it "should parse a single digit integer string" do
+    it "parses a single digit integer string" do
       expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
   
-    it "should parse a double digit integer string" do
+    it "parses a double digit integer string" do
       expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
   
-    it "should parse an integer string amount with a leading $" do
+    it "parses an integer string amount with a leading $" do
       expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
   
-    it "should parse a float string amount" do
+    it "parses a float string amount" do
       expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
   
-    it "should parse a float string amount with a leading $" do
+    it "parses a float string amount with a leading $" do
       expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
   
-    it "should parse a float string with a single digit after the decimal" do
+    it "parses a float string with a single digit after the decimal" do
       expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
   
-    it "should parse a float string with two digits after the decimal" do
+    it "parses a float string with two digits after the decimal" do
       expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
   
-    it "should parse the amount from an amount surrounded by whitespace and garbage" do
+    it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse the amount from an amount surrounded by garbage" do
+    it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse a negative integer amount in the hundreds" do
+    it "parses a negative integer amount in the hundreds" do
       expect(@parser.parse("-100")).to eq(Money.new(-100.00))
     end
 
-    it "should parse an integer amount in the hundreds" do
+    it "parses an integer amount in the hundreds" do
       expect(@parser.parse("410")).to eq(Money.new(410.00))
     end
 
-    it "should parse a positive amount with a thousands separator" do
+    it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
   
-    it "should parse a negative amount with a thousands separator" do
+    it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
 
-    it "should parse negative $1.00" do
+    it "parses negative $1.00" do
       expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
     end
 
-    it "should parse a negative cents amount" do
+    it "parses a negative cents amount" do
       expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
     
-    it "should parse amount with 3 decimals and 0 dollar amount" do
+    it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
     
-    it "should parse negative amount with 3 decimals and 0 dollar amount" do
+    it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
     
-    it "should parse negative amount with multiple leading - signs" do
+    it "parses negative amount with multiple leading - signs" do
       expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
     
-    it "should parse negative amount with multiple - signs" do
+    it "parses negative amount with multiple - signs" do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
   end
@@ -96,47 +96,47 @@ describe MoneyParser do
       @parser = MoneyParser.new
     end
     
-    it "should parse dollar amount $1,00 with leading $" do
+    it "parses dollar amount $1,00 with leading $" do
       expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
 
-    it "should parse dollar amount $1,37 with leading $, and non-zero cents" do
+    it "parses dollar amount $1,37 with leading $, and non-zero cents" do
       expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
     
-    it "should parse the amount from an amount surrounded by whitespace and garbage" do
+    it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
 
-    it "should parse the amount from an amount surrounded by garbage" do
+    it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
     
-    it "should parse thousands amount" do
+    it "parses thousands amount" do
       expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
     
-    it "should parse negative hundreds amount" do
+    it "parses negative hundreds amount" do
       expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
     
-    it "should parse positive hundreds amount" do
+    it "parses positive hundreds amount" do
       expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
     
-    it "should parse a positive amount with a thousands separator" do
+    it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
   
-    it "should parse a negative amount with a thousands separator" do
+    it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
     
-    it "should parse amount with 3 decimals and 0 dollar amount" do
+    it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
     
-    it "should parse negative amount with 3 decimals and 0 dollar amount" do
+    it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
@@ -146,47 +146,47 @@ describe MoneyParser do
       @parser = MoneyParser.new
     end
     
-    it "should parse 50.0" do
+    it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
     
-    it "should parse 50.1" do
+    it "parses 50.1" do
       expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
     
-    it "should parse 50.2" do
+    it "parses 50.2" do
       expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
     
-    it "should parse 50.3" do
+    it "parses 50.3" do
       expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
     
-    it "should parse 50.4" do
+    it "parses 50.4" do
       expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
     
-    it "should parse 50.5" do
+    it "parses 50.5" do
       expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
     
-    it "should parse 50.6" do
+    it "parses 50.6" do
       expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
     
-    it "should parse 50.7" do
+    it "parses 50.7" do
       expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
     
-    it "should parse 50.8" do
+    it "parses 50.8" do
       expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
     
-    it "should parse 50.9" do
+    it "parses 50.9" do
       expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
     
-    it "should parse 50.10" do
+    it "parses 50.10" do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -7,87 +7,87 @@ describe MoneyParser do
     end
   
     it "should parse an empty string to $0" do
-      @parser.parse("").should == Money.new
+      expect(@parser.parse("")).to eq(Money.new)
     end
   
     it "should parse an invalid string to $0" do
-      @parser.parse("no money").should == Money.new
+      expect(@parser.parse("no money")).to eq(Money.new)
     end
   
     it "should parse a single digit integer string" do
-      @parser.parse("1").should == Money.new(1.00)
+      expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
   
     it "should parse a double digit integer string" do
-      @parser.parse("10").should == Money.new(10.00)
+      expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
   
     it "should parse an integer string amount with a leading $" do
-      @parser.parse("$1").should == Money.new(1.00)
+      expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
   
     it "should parse a float string amount" do
-      @parser.parse("1.37").should == Money.new(1.37)
+      expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
   
     it "should parse a float string amount with a leading $" do
-      @parser.parse("$1.37").should == Money.new(1.37)
+      expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
   
     it "should parse a float string with a single digit after the decimal" do
-      @parser.parse("10.0").should == Money.new(10.00)
+      expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
   
     it "should parse a float string with two digits after the decimal" do
-      @parser.parse("10.00").should == Money.new(10.00)
+      expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
   
     it "should parse the amount from an amount surrounded by whitespace and garbage" do
-      @parser.parse("Rubbish $1.00 Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse the amount from an amount surrounded by garbage" do
-      @parser.parse("Rubbish$1.00Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse a negative integer amount in the hundreds" do
-      @parser.parse("-100").should == Money.new(-100.00)
+      expect(@parser.parse("-100")).to eq(Money.new(-100.00))
     end
 
     it "should parse an integer amount in the hundreds" do
-      @parser.parse("410").should == Money.new(410.00)
+      expect(@parser.parse("410")).to eq(Money.new(410.00))
     end
 
     it "should parse a positive amount with a thousands separator" do
-      @parser.parse("100,000.00").should == Money.new(100_000.00)
+      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
   
     it "should parse a negative amount with a thousands separator" do
-      @parser.parse("-100,000.00").should == Money.new(-100_000.00)
+      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
 
     it "should parse negative $1.00" do
-      @parser.parse("-1.00").should == Money.new(-1.00)
+      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
     end
 
     it "should parse a negative cents amount" do
-      @parser.parse("-0.90").should == Money.new(-0.90)
+      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
     
     it "should parse amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("0.123").should == Money.new(0.12)
+      expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
     
     it "should parse negative amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("-0.123").should == Money.new(-0.12)
+      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
     
     it "should parse negative amount with multiple leading - signs" do
-      @parser.parse("--0.123").should == Money.new(-0.12)
+      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
     
     it "should parse negative amount with multiple - signs" do
-      @parser.parse("--0.123--").should == Money.new(-0.12)
+      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
   end
 
@@ -97,47 +97,47 @@ describe MoneyParser do
     end
     
     it "should parse dollar amount $1,00 with leading $" do
-      @parser.parse("$1,00").should == Money.new(1.00)
+      expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
 
     it "should parse dollar amount $1,37 with leading $, and non-zero cents" do
-      @parser.parse("$1,37").should == Money.new(1.37)
+      expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
     
     it "should parse the amount from an amount surrounded by whitespace and garbage" do
-      @parser.parse("Rubbish $1,00 Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
 
     it "should parse the amount from an amount surrounded by garbage" do
-      @parser.parse("Rubbish$1,00Rubbish").should == Money.new(1.00)
+      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
     
     it "should parse thousands amount" do
-      @parser.parse("1.000").should == Money.new(1000.00)
+      expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
     
     it "should parse negative hundreds amount" do
-      @parser.parse("-100,00").should == Money.new(-100.00)
+      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
     
     it "should parse positive hundreds amount" do
-      @parser.parse("410,00").should == Money.new(410.00)
+      expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
     
     it "should parse a positive amount with a thousands separator" do
-      @parser.parse("100.000,00").should == Money.new(100_000.00)
+      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
   
     it "should parse a negative amount with a thousands separator" do
-      @parser.parse("-100.000,00").should == Money.new(-100_000.00)
+      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
     
     it "should parse amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("0,123").should == Money.new(0.12)
+      expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
     
     it "should parse negative amount with 3 decimals and 0 dollar amount" do
-      @parser.parse("-0,123").should == Money.new(-0.12)
+      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
   
@@ -147,47 +147,47 @@ describe MoneyParser do
     end
     
     it "should parse 50.0" do
-      @parser.parse("50.0").should == Money.new(50.00)
+      expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
     
     it "should parse 50.1" do
-      @parser.parse("50.1").should == Money.new(50.10)
+      expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
     
     it "should parse 50.2" do
-      @parser.parse("50.2").should == Money.new(50.20)
+      expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
     
     it "should parse 50.3" do
-      @parser.parse("50.3").should == Money.new(50.30)
+      expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
     
     it "should parse 50.4" do
-      @parser.parse("50.4").should == Money.new(50.40)
+      expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
     
     it "should parse 50.5" do
-      @parser.parse("50.5").should == Money.new(50.50)
+      expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
     
     it "should parse 50.6" do
-      @parser.parse("50.6").should == Money.new(50.60)
+      expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
     
     it "should parse 50.7" do
-      @parser.parse("50.7").should == Money.new(50.70)
+      expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
     
     it "should parse 50.8" do
-      @parser.parse("50.8").should == Money.new(50.80)
+      expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
     
     it "should parse 50.9" do
-      @parser.parse("50.9").should == Money.new(50.90)
+      expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
     
     it "should parse 50.10" do
-      @parser.parse("50.10").should == Money.new(50.10)
+      expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -6,161 +6,161 @@ describe "Money" do
     @money = Money.new
   end
 
-  it "should be contructable with empty class method" do
+  it "is contructable with empty class method" do
     expect(Money.empty).to eq(@money)
   end
 
-  it "should return itself with to_money" do
+  it "returns itself with to_money" do
     expect(@money.to_money).to eq(@money)
   end
 
-  it "should default to 0 when constructed with no arguments" do
+  it "defaults to 0 when constructed with no arguments" do
     expect(@money).to eq(Money.new(0.00))
   end
 
-  it "should to_s as a float with 2 decimal places" do
+  it "to_s as a float with 2 decimal places" do
     expect(@money.to_s).to eq("0.00")
   end
 
-  it "should be constructable with a BigDecimal" do
+  it "is constructable with a BigDecimal" do
     expect(Money.new(BigDecimal.new("1.23"))).to eq(Money.new(1.23))
   end
 
-  it "should be constructable with a Fixnum" do
+  it "is constructable with a Fixnum" do
     expect(Money.new(3)).to eq(Money.new(3.00))
   end
 
-  it "should be construcatable with a Float" do
+  it "is construcatable with a Float" do
     expect(Money.new(3.00)).to eq(Money.new(3.00))
   end
 
-  it "should be addable" do
+  it "is addable" do
     expect((Money.new(1.51) + Money.new(3.49))).to eq(Money.new(5.00))
   end
 
-  it "should be able to add $0 + $0" do
+  it "is able to add $0 + $0" do
     expect((Money.new + Money.new)).to eq(Money.new)
   end
 
-  it "should be subtractable" do
+  it "is subtractable" do
     expect((Money.new(5.00) - Money.new(3.49))).to eq(Money.new(1.51))
   end
 
-  it "should be subtractable to $0" do
+  it "is subtractable to $0" do
     expect((Money.new(5.00) - Money.new(5.00))).to eq(Money.new)
   end
 
-  it "should be substractable to a negative amount" do
+  it "is substractable to a negative amount" do
     expect((Money.new(0.00) - Money.new(1.00))).to eq(Money.new("-1.00"))
   end
 
-  it "should inspect to a presentable string" do
+  it "inspects to a presentable string" do
     expect(@money.inspect).to eq("#<Money value:0.00>")
   end
 
-  it "should be inspectable within an array" do
+  it "is inspectable within an array" do
     expect([@money].inspect).to eq("[#<Money value:0.00>]")
   end
 
-  it "should correctly support eql? as a value object" do
+  it "correctly support eql? as a value object" do
     expect(@money).to eq(Money.new)
   end
 
-  it "should be addable with integer" do
+  it "is addable with integer" do
     expect((Money.new(1.33) + 1)).to eq(Money.new(2.33))
     expect((1 + Money.new(1.33))).to eq(Money.new(2.33))
   end
 
-  it "should be addable with float" do
+  it "is addable with float" do
     expect((Money.new(1.33) + 1.50)).to eq(Money.new(2.83))
     expect((1.50 + Money.new(1.33))).to eq(Money.new(2.83))
   end
 
-  it "should be subtractable with integer" do
+  it "is subtractable with integer" do
     expect((Money.new(1.66) - 1)).to eq(Money.new(0.66))
     expect((2 - Money.new(1.66))).to eq(Money.new(0.34))
   end
 
-  it "should be subtractable with float" do
+  it "is subtractable with float" do
     expect((Money.new(1.66) - 1.50)).to eq(Money.new(0.16))
     expect((1.50 - Money.new(1.33))).to eq(Money.new(0.17))
   end
 
-  it "should be multipliable with an integer" do
+  it "is multipliable with an integer" do
     expect((Money.new(1.00) * 55)).to eq(Money.new(55.00))
     expect((55 * Money.new(1.00))).to eq(Money.new(55.00))
   end
 
-  it "should be multiplable with a float" do
+  it "is multiplable with a float" do
     expect((Money.new(1.00) * 1.50)).to eq(Money.new(1.50))
     expect((1.50 * Money.new(1.00))).to eq(Money.new(1.50))
   end
 
-  it "should be multipliable by a cents amount" do
+  it "is multipliable by a cents amount" do
     expect((Money.new(1.00) * 0.50)).to eq(Money.new(0.50))
     expect((0.50 * Money.new(1.00))).to eq(Money.new(0.50))
   end
 
-  it "should be multipliable by a repeatable floating point number" do
+  it "is multipliable by a repeatable floating point number" do
     expect((Money.new(24.00) * (1 / 30.0))).to eq(Money.new(0.80))
     expect(((1 / 30.0) * Money.new(24.00))).to eq(Money.new(0.80))
   end
 
-  it "should round multiplication result with fractional penny of 5 or higher up" do
+  it "rounds multiplication result with fractional penny of 5 or higher up" do
     expect((Money.new(0.03) * 0.5)).to eq(Money.new(0.02))
     expect((0.5 * Money.new(0.03))).to eq(Money.new(0.02))
   end
 
-  it "should round multiplication result with fractional penny of 4 or lower down" do
+  it "rounds multiplication result with fractional penny of 4 or lower down" do
     expect((Money.new(0.10) * 0.33)).to eq(Money.new(0.03))
     expect((0.33 * Money.new(0.10))).to eq(Money.new(0.03))
   end
 
-  it "should raise if divided" do
+  it "raises if divided" do
     expect { Money.new(55.00) / 55 }.to raise_error
   end
 
-  it "should return cents in to_liquid" do
+  it "returns cents in to_liquid" do
     expect(Money.new(1.00).to_liquid).to eq(100)
   end
 
-  it "should return cents in to_json" do
+  it "returns cents in to_json" do
     expect(Money.new(1.00).to_json).to eq("1.00")
   end
 
-  it "should support absolute value" do
+  it "supports absolute value" do
     expect(Money.new(-1.00).abs).to eq(Money.new(1.00))
   end
 
-  it "should support to_i" do
+  it "supports to_i" do
     expect(Money.new(1.50).to_i).to eq(1)
   end
 
-  it "should support to_f" do
+  it "supports to_f" do
     expect(Money.new(1.50).to_f.to_s).to eq("1.5")
   end
 
-  it "should be creatable from an integer value in cents" do
+  it "is creatable from an integer value in cents" do
     expect(Money.from_cents(1950)).to eq(Money.new(19.50))
   end
 
-  it "should be creatable from an integer value of 0 in cents" do
+  it "is creatable from an integer value of 0 in cents" do
     expect(Money.from_cents(0)).to eq(Money.new)
   end
 
-  it "should be creatable from a float cents amount" do
+  it "is creatable from a float cents amount" do
     expect(Money.from_cents(1950.5)).to eq(Money.new(19.51))
   end
 
-  it "should raise when constructed with a NaN value" do
+  it "raises when constructed with a NaN value" do
     expect { Money.new( 0.0 / 0) }.to raise_error
   end
 
-  it "should be comparable with non-money objects" do
+  it "is comparable with non-money objects" do
     expect(@money).not_to eq(nil)
   end
 
-  it "should support floor" do
+  it "supports floor" do
     expect(Money.new(15.52).floor).to eq(Money.new(15.00))
     expect(Money.new(18.99).floor).to eq(Money.new(18.00))
     expect(Money.new(21).floor).to eq(Money.new(21))
@@ -171,23 +171,23 @@ describe "Money" do
       @money = Money.new(1.00).freeze
     end
 
-    it "should == $1" do
+    it "is equals to $1" do
       expect(@money).to eq(Money.new(1.00))
     end
 
-    it "should not == $2" do
+    it "is not equals to $2" do
       expect(@money).not_to eq(Money.new(2.00))
     end
 
-    it "<=> $1 should be 0" do
+    it "<=> $1 is 0" do
       expect((@money <=> Money.new(1.00))).to eq(0)
     end
 
-    it "<=> $2 should be -1" do
+    it "<=> $2 is -1" do
       expect((@money <=> Money.new(2.00))).to eq(-1)
     end
 
-    it "<=> $0.50 should equal 1" do
+    it "<=> $0.50 equals 1" do
       expect((@money <=> Money.new(0.50))).to eq(1)
     end
 
@@ -200,11 +200,11 @@ describe "Money" do
       expect((0.5 <=> @money)).to eq(-1)
     end
 
-    it "should have the same hash value as $1" do
+    it "have the same hash value as $1" do
       expect(@money.hash).to eq(Money.new(1.00).hash)
     end
 
-    it "should not have the same hash value as $2" do
+    it "does not have the same hash value as $2" do
       expect(@money.hash).to eq(Money.new(1.00).hash)
     end
 
@@ -215,23 +215,23 @@ describe "Money" do
       @money = Money.new
     end
 
-    it "should be zero" do
+    it "is zero" do
       expect(@money).to be_zero
     end
 
-    it "should be greater than -$1" do
+    it "is greater than -$1" do
       expect(@money).to be > Money.new("-1.00")
     end
 
-    it "should be greater than or equal to $0" do
+    it "is greater than or equal to $0" do
       expect(@money).to be >= Money.new
     end
 
-    it "should be less than or equal to $0" do
+    it "is less than or equal to $0" do
       expect(@money).to be <= Money.new
     end
 
-    it "should be less than $1" do
+    it "is less than $1" do
       expect(@money).to be < Money.new(1.00)
     end
   end
@@ -241,31 +241,31 @@ describe "Money" do
       @money = Money.new(1.00)
     end
 
-    it "should not be zero" do
+    it "is not zero" do
       expect(@money).not_to be_zero
     end
 
-    it "should have a decimal value = 1.00" do
+    it "returns cents as a decimal value = 1.00" do
       expect(@money.value).to eq(BigDecimal.new("1.00"))
     end
 
-    it "should have 100 cents" do
+    it "returns cents as 100 cents" do
       expect(@money.cents).to eq(100)
     end
 
-    it "should return cents as a Fixnum" do
+    it "returns cents as a Fixnum" do
       expect(@money.cents).to be_an_instance_of(Fixnum)
     end
 
-    it "should be greater than $0" do
+    it "is greater than $0" do
       expect(@money).to be > Money.new(0.00)
     end
 
-    it "should be less than $2" do
+    it "is less than $2" do
       expect(@money).to be < Money.new(2.00)
     end
 
-    it "should be equal to $1" do
+    it "is equal to $1" do
       expect(@money).to eq(Money.new(1.00))
     end
   end
@@ -336,7 +336,7 @@ describe "Money" do
       @money = Money.new(1.125)
     end
 
-    it "should round 3rd decimal place" do
+    it "rounds 3rd decimal place" do
       expect(@money.value).to eq(BigDecimal.new("1.13"))
     end
   end
@@ -346,15 +346,15 @@ describe "Money" do
       Money.parser = AccountingMoneyParser
     end
 
-    it "should keep AccountingMoneyParser class on new money objects" do
+    it "keeps AccountingMoneyParser class on new money objects" do
       expect(Money.new.class.parser).to eq(AccountingMoneyParser)
     end
 
-    it "should support parenthesis from AccountingMoneyParser" do
+    it "supports parenthesis from AccountingMoneyParser" do
       expect(Money.parse("($5.00)")).to eq(Money.new(-5))
     end
 
-    it "should support parenthesis from AccountingMoneyParser for .to_money" do
+    it "supports parenthesis from AccountingMoneyParser for .to_money" do
       expect("($5.00)".to_money).to eq(Money.new(-5))
     end
 
@@ -365,20 +365,20 @@ describe "Money" do
   
   describe "round" do
     
-    it "should round to 0 decimal places by default" do
+    it "rounds to 0 decimal places by default" do
       expect(Money.new(54.1).round).to eq(Money.new(54))
       expect(Money.new(54.5).round).to eq(Money.new(55))
     end
     
     # Overview of standard vs. banker's rounding for next 4 specs:
     # http://www.xbeat.net/vbspeed/i_BankersRounding.htm
-    it "should implement standard rounding for 2 digits" do
+    it "implements standard rounding for 2 digits" do
       expect(Money.new(54.1754).round(2)).to eq(Money.new(54.18))
       expect(Money.new(343.2050).round(2)).to eq(Money.new(343.21))
       expect(Money.new(106.2038).round(2)).to eq(Money.new(106.20))
     end
 
-    it "should implement standard rounding for 1 digit" do
+    it "implements standard rounding for 1 digit" do
       expect(Money.new(27.25).round(1)).to eq(Money.new(27.3))
       expect(Money.new(27.45).round(1)).to eq(Money.new(27.5))
       expect(Money.new(27.55).round(1)).to eq(Money.new(27.6))

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -7,163 +7,163 @@ describe "Money" do
   end
 
   it "should be contructable with empty class method" do
-    Money.empty.should == @money
+    expect(Money.empty).to eq(@money)
   end
 
   it "should return itself with to_money" do
-    @money.to_money.should equal(@money)
+    expect(@money.to_money).to eq(@money)
   end
 
   it "should default to 0 when constructed with no arguments" do
-    @money.should == Money.new(0.00)
+    expect(@money).to eq(Money.new(0.00))
   end
 
   it "should to_s as a float with 2 decimal places" do
-    @money.to_s.should == "0.00"
+    expect(@money.to_s).to eq("0.00")
   end
 
   it "should be constructable with a BigDecimal" do
-    Money.new(BigDecimal.new("1.23")).should == Money.new(1.23)
+    expect(Money.new(BigDecimal.new("1.23"))).to eq(Money.new(1.23))
   end
 
   it "should be constructable with a Fixnum" do
-    Money.new(3).should == Money.new(3.00)
+    expect(Money.new(3)).to eq(Money.new(3.00))
   end
 
   it "should be construcatable with a Float" do
-    Money.new(3.00).should == Money.new(3.00)
+    expect(Money.new(3.00)).to eq(Money.new(3.00))
   end
 
   it "should be addable" do
-    (Money.new(1.51) + Money.new(3.49)).should == Money.new(5.00)
+    expect((Money.new(1.51) + Money.new(3.49))).to eq(Money.new(5.00))
   end
 
   it "should be able to add $0 + $0" do
-    (Money.new + Money.new).should == Money.new
+    expect((Money.new + Money.new)).to eq(Money.new)
   end
 
   it "should be subtractable" do
-    (Money.new(5.00) - Money.new(3.49)).should == Money.new(1.51)
+    expect((Money.new(5.00) - Money.new(3.49))).to eq(Money.new(1.51))
   end
 
   it "should be subtractable to $0" do
-    (Money.new(5.00) - Money.new(5.00)).should == Money.new
+    expect((Money.new(5.00) - Money.new(5.00))).to eq(Money.new)
   end
 
   it "should be substractable to a negative amount" do
-    (Money.new(0.00) - Money.new(1.00)).should == Money.new("-1.00")
+    expect((Money.new(0.00) - Money.new(1.00))).to eq(Money.new("-1.00"))
   end
 
   it "should inspect to a presentable string" do
-    @money.inspect.should == "#<Money value:0.00>"
+    expect(@money.inspect).to eq("#<Money value:0.00>")
   end
 
   it "should be inspectable within an array" do
-    [@money].inspect.should == "[#<Money value:0.00>]"
+    expect([@money].inspect).to eq("[#<Money value:0.00>]")
   end
 
   it "should correctly support eql? as a value object" do
-    @money.should eql(Money.new)
+    expect(@money).to eq(Money.new)
   end
 
   it "should be addable with integer" do
-    (Money.new(1.33) + 1).should == Money.new(2.33)
-    (1 + Money.new(1.33)).should == Money.new(2.33)
+    expect((Money.new(1.33) + 1)).to eq(Money.new(2.33))
+    expect((1 + Money.new(1.33))).to eq(Money.new(2.33))
   end
 
   it "should be addable with float" do
-    (Money.new(1.33) + 1.50).should == Money.new(2.83)
-    (1.50 + Money.new(1.33)).should == Money.new(2.83)
+    expect((Money.new(1.33) + 1.50)).to eq(Money.new(2.83))
+    expect((1.50 + Money.new(1.33))).to eq(Money.new(2.83))
   end
 
   it "should be subtractable with integer" do
-    (Money.new(1.66) - 1).should == Money.new(0.66)
-    (2 - Money.new(1.66)).should == Money.new(0.34)
+    expect((Money.new(1.66) - 1)).to eq(Money.new(0.66))
+    expect((2 - Money.new(1.66))).to eq(Money.new(0.34))
   end
 
   it "should be subtractable with float" do
-    (Money.new(1.66) - 1.50).should == Money.new(0.16)
-    (1.50 - Money.new(1.33)).should == Money.new(0.17)
+    expect((Money.new(1.66) - 1.50)).to eq(Money.new(0.16))
+    expect((1.50 - Money.new(1.33))).to eq(Money.new(0.17))
   end
 
   it "should be multipliable with an integer" do
-    (Money.new(1.00) * 55).should == Money.new(55.00)
-    (55 * Money.new(1.00)).should == Money.new(55.00)
+    expect((Money.new(1.00) * 55)).to eq(Money.new(55.00))
+    expect((55 * Money.new(1.00))).to eq(Money.new(55.00))
   end
 
   it "should be multiplable with a float" do
-    (Money.new(1.00) * 1.50).should == Money.new(1.50)
-    (1.50 * Money.new(1.00)).should == Money.new(1.50)
+    expect((Money.new(1.00) * 1.50)).to eq(Money.new(1.50))
+    expect((1.50 * Money.new(1.00))).to eq(Money.new(1.50))
   end
 
   it "should be multipliable by a cents amount" do
-    (Money.new(1.00) * 0.50).should == Money.new(0.50)
-    (0.50 * Money.new(1.00)).should == Money.new(0.50)
+    expect((Money.new(1.00) * 0.50)).to eq(Money.new(0.50))
+    expect((0.50 * Money.new(1.00))).to eq(Money.new(0.50))
   end
 
   it "should be multipliable by a repeatable floating point number" do
-    (Money.new(24.00) * (1 / 30.0)).should == Money.new(0.80)
-    ((1 / 30.0) * Money.new(24.00)).should == Money.new(0.80)
+    expect((Money.new(24.00) * (1 / 30.0))).to eq(Money.new(0.80))
+    expect(((1 / 30.0) * Money.new(24.00))).to eq(Money.new(0.80))
   end
 
   it "should round multiplication result with fractional penny of 5 or higher up" do
-    (Money.new(0.03) * 0.5).should == Money.new(0.02)
-    (0.5 * Money.new(0.03)).should == Money.new(0.02)
+    expect((Money.new(0.03) * 0.5)).to eq(Money.new(0.02))
+    expect((0.5 * Money.new(0.03))).to eq(Money.new(0.02))
   end
 
   it "should round multiplication result with fractional penny of 4 or lower down" do
-    (Money.new(0.10) * 0.33).should == Money.new(0.03)
-    (0.33 * Money.new(0.10)).should == Money.new(0.03)
+    expect((Money.new(0.10) * 0.33)).to eq(Money.new(0.03))
+    expect((0.33 * Money.new(0.10))).to eq(Money.new(0.03))
   end
 
   it "should raise if divided" do
-    lambda { Money.new(55.00) / 55 }.should raise_error
+    expect { Money.new(55.00) / 55 }.to raise_error
   end
 
   it "should return cents in to_liquid" do
-    Money.new(1.00).to_liquid.should == 100
+    expect(Money.new(1.00).to_liquid).to eq(100)
   end
 
   it "should return cents in to_json" do
-    Money.new(1.00).to_json.should == "1.00"
+    expect(Money.new(1.00).to_json).to eq("1.00")
   end
 
   it "should support absolute value" do
-    Money.new(-1.00).abs.should == Money.new(1.00)
+    expect(Money.new(-1.00).abs).to eq(Money.new(1.00))
   end
 
   it "should support to_i" do
-    Money.new(1.50).to_i.should == 1
+    expect(Money.new(1.50).to_i).to eq(1)
   end
 
   it "should support to_f" do
-    Money.new(1.50).to_f.to_s.should == "1.5"
+    expect(Money.new(1.50).to_f.to_s).to eq("1.5")
   end
 
   it "should be creatable from an integer value in cents" do
-    Money.from_cents(1950).should == Money.new(19.50)
+    expect(Money.from_cents(1950)).to eq(Money.new(19.50))
   end
 
   it "should be creatable from an integer value of 0 in cents" do
-    Money.from_cents(0).should == Money.new
+    expect(Money.from_cents(0)).to eq(Money.new)
   end
 
   it "should be creatable from a float cents amount" do
-    Money.from_cents(1950.5).should == Money.new(19.51)
+    expect(Money.from_cents(1950.5)).to eq(Money.new(19.51))
   end
 
   it "should raise when constructed with a NaN value" do
-    lambda{ Money.new( 0.0 / 0) }.should raise_error
+    expect { Money.new( 0.0 / 0) }.to raise_error
   end
 
   it "should be comparable with non-money objects" do
-    @money.should_not == nil
+    expect(@money).not_to eq(nil)
   end
 
   it "should support floor" do
-    Money.new(15.52).floor.should == Money.new(15.00)
-    Money.new(18.99).floor.should == Money.new(18.00)
-    Money.new(21).floor.should == Money.new(21)
+    expect(Money.new(15.52).floor).to eq(Money.new(15.00))
+    expect(Money.new(18.99).floor).to eq(Money.new(18.00))
+    expect(Money.new(21).floor).to eq(Money.new(21))
   end
 
   describe "frozen with amount of $1" do
@@ -172,40 +172,40 @@ describe "Money" do
     end
 
     it "should == $1" do
-      @money.should == Money.new(1.00)
+      expect(@money).to eq(Money.new(1.00))
     end
 
     it "should not == $2" do
-      @money.should_not == Money.new(2.00)
+      expect(@money).not_to eq(Money.new(2.00))
     end
 
     it "<=> $1 should be 0" do
-      (@money <=> Money.new(1.00)).should == 0
+      expect((@money <=> Money.new(1.00))).to eq(0)
     end
 
     it "<=> $2 should be -1" do
-      (@money <=> Money.new(2.00)).should == -1
+      expect((@money <=> Money.new(2.00))).to eq(-1)
     end
 
     it "<=> $0.50 should equal 1" do
-      (@money <=> Money.new(0.50)).should == 1
+      expect((@money <=> Money.new(0.50))).to eq(1)
     end
 
     it "<=> works with non-money objects" do
-      (@money <=> 1).should == 0
-      (@money <=> 2).should == -1
-      (@money <=> 0.5).should == 1
-      (1 <=> @money).should == 0
-      (2 <=> @money).should == 1
-      (0.5 <=> @money).should == -1
+      expect((@money <=> 1)).to eq(0)
+      expect((@money <=> 2)).to eq(-1)
+      expect((@money <=> 0.5)).to eq(1)
+      expect((1 <=> @money)).to eq(0)
+      expect((2 <=> @money)).to eq(1)
+      expect((0.5 <=> @money)).to eq(-1)
     end
 
     it "should have the same hash value as $1" do
-      @money.hash.should == Money.new(1.00).hash
+      expect(@money.hash).to eq(Money.new(1.00).hash)
     end
 
     it "should not have the same hash value as $2" do
-      @money.hash.should == Money.new(1.00).hash
+      expect(@money.hash).to eq(Money.new(1.00).hash)
     end
 
   end
@@ -216,23 +216,23 @@ describe "Money" do
     end
 
     it "should be zero" do
-      @money.should be_zero
+      expect(@money).to be_zero
     end
 
     it "should be greater than -$1" do
-      @money.should be > Money.new("-1.00")
+      expect(@money).to be > Money.new("-1.00")
     end
 
     it "should be greater than or equal to $0" do
-      @money.should be >= Money.new
+      expect(@money).to be >= Money.new
     end
 
     it "should be less than or equal to $0" do
-      @money.should be <= Money.new
+      expect(@money).to be <= Money.new
     end
 
     it "should be less than $1" do
-      @money.should be < Money.new(1.00)
+      expect(@money).to be < Money.new(1.00)
     end
   end
 
@@ -242,92 +242,92 @@ describe "Money" do
     end
 
     it "should not be zero" do
-      @money.should_not be_zero
+      expect(@money).not_to be_zero
     end
 
     it "should have a decimal value = 1.00" do
-      @money.value.should == BigDecimal.new("1.00")
+      expect(@money.value).to eq(BigDecimal.new("1.00"))
     end
 
     it "should have 100 cents" do
-      @money.cents.should == 100
+      expect(@money.cents).to eq(100)
     end
 
     it "should return cents as a Fixnum" do
-      @money.cents.should be_an_instance_of(Fixnum)
+      expect(@money.cents).to be_an_instance_of(Fixnum)
     end
 
     it "should be greater than $0" do
-      @money.should be > Money.new(0.00)
+      expect(@money).to be > Money.new(0.00)
     end
 
     it "should be less than $2" do
-      @money.should be < Money.new(2.00)
+      expect(@money).to be < Money.new(2.00)
     end
 
     it "should be equal to $1" do
-      @money.should == Money.new(1.00)
+      expect(@money).to eq(Money.new(1.00))
     end
   end
 
   describe "allocation"do
     specify "#allocate takes no action when one gets all" do
-      Money.new(5).allocate([1]).should == [Money.new(5)]
+      expect(Money.new(5).allocate([1])).to eq([Money.new(5)])
     end
 
     specify "#allocate does not lose pennies" do
       moneys = Money.new(0.05).allocate([0.3,0.7])
-      moneys[0].should == Money.new(0.02)
-      moneys[1].should == Money.new(0.03)
+      expect(moneys[0]).to eq(Money.new(0.02))
+      expect(moneys[1]).to eq(Money.new(0.03))
     end
 
     specify "#allocate does not lose pennies even when given a lossy split" do
       moneys = Money.new(1).allocate([0.333,0.333, 0.333])
-      moneys[0].cents.should == 34
-      moneys[1].cents.should == 33
-      moneys[2].cents.should == 33
+      expect(moneys[0].cents).to eq(34)
+      expect(moneys[1].cents).to eq(33)
+      expect(moneys[2].cents).to eq(33)
     end
 
     specify "#allocate requires total to be less then 1" do
-      lambda { Money.new(0.05).allocate([0.5,0.6]) }.should raise_error(ArgumentError)
+      expect { Money.new(0.05).allocate([0.5,0.6]) }.to raise_error(ArgumentError)
     end
   end
 
   describe "split" do
     specify "#split needs at least one party" do
-      lambda {Money.new(1).split(0)}.should raise_error(ArgumentError)
-      lambda {Money.new(1).split(-1)}.should raise_error(ArgumentError)
+      expect {Money.new(1).split(0)}.to raise_error(ArgumentError)
+      expect {Money.new(1).split(-1)}.to raise_error(ArgumentError)
     end
 
     specify "#gives 1 cent to both people if we start with 2" do
-      Money.new(0.02).split(2).should == [Money.new(0.01), Money.new(0.01)]
+      expect(Money.new(0.02).split(2)).to eq([Money.new(0.01), Money.new(0.01)])
     end
 
     specify "#split may distribute no money to some parties if there isnt enough to go around" do
-      Money.new(0.02).split(3).should == [Money.new(0.01), Money.new(0.01), Money.new(0)]
+      expect(Money.new(0.02).split(3)).to eq([Money.new(0.01), Money.new(0.01), Money.new(0)])
     end
 
     specify "#split does not lose pennies" do
-      Money.new(0.05).split(2).should == [Money.new(0.03), Money.new(0.02)]
+      expect(Money.new(0.05).split(2)).to eq([Money.new(0.03), Money.new(0.02)])
     end
 
     specify "#split a dollar" do
       moneys = Money.new(1).split(3)
-      moneys[0].cents.should == 34
-      moneys[1].cents.should == 33
-      moneys[2].cents.should == 33
+      expect(moneys[0].cents).to eq(34)
+      expect(moneys[1].cents).to eq(33)
+      expect(moneys[2].cents).to eq(33)
     end
   end
 
   describe "fraction" do
     specify "#fraction needs a positive rate" do
-      lambda {Money.new(1).fraction(-0.5)}.should raise_error(ArgumentError)
+      expect {Money.new(1).fraction(-0.5)}.to raise_error(ArgumentError)
     end
 
     specify "#fraction returns the amount minus a fraction" do
-      Money.new(1.15).fraction(0.15).should == Money.new(1.00)
-      Money.new(2.50).fraction(0.15).should == Money.new(2.17)
-      Money.new(35.50).fraction(0).should == Money.new(35.50)
+      expect(Money.new(1.15).fraction(0.15)).to eq(Money.new(1.00))
+      expect(Money.new(2.50).fraction(0.15)).to eq(Money.new(2.17))
+      expect(Money.new(35.50).fraction(0)).to eq(Money.new(35.50))
     end
   end
 
@@ -337,7 +337,7 @@ describe "Money" do
     end
 
     it "should round 3rd decimal place" do
-      @money.value.should == BigDecimal.new("1.13")
+      expect(@money.value).to eq(BigDecimal.new("1.13"))
     end
   end
 
@@ -347,15 +347,15 @@ describe "Money" do
     end
 
     it "should keep AccountingMoneyParser class on new money objects" do
-      Money.new.class.parser.should == AccountingMoneyParser
+      expect(Money.new.class.parser).to eq(AccountingMoneyParser)
     end
 
     it "should support parenthesis from AccountingMoneyParser" do
-      Money.parse("($5.00)").should == Money.new(-5)
+      expect(Money.parse("($5.00)")).to eq(Money.new(-5))
     end
 
     it "should support parenthesis from AccountingMoneyParser for .to_money" do
-      "($5.00)".to_money.should == Money.new(-5)
+      expect("($5.00)".to_money).to eq(Money.new(-5))
     end
 
     after(:each) do
@@ -366,22 +366,22 @@ describe "Money" do
   describe "round" do
     
     it "should round to 0 decimal places by default" do
-      Money.new(54.1).round.should == Money.new(54)
-      Money.new(54.5).round.should == Money.new(55)
+      expect(Money.new(54.1).round).to eq(Money.new(54))
+      expect(Money.new(54.5).round).to eq(Money.new(55))
     end
     
     # Overview of standard vs. banker's rounding for next 4 specs:
     # http://www.xbeat.net/vbspeed/i_BankersRounding.htm
     it "should implement standard rounding for 2 digits" do
-      Money.new(54.1754).round(2).should == Money.new(54.18)
-      Money.new(343.2050).round(2).should == Money.new(343.21)
-      Money.new(106.2038).round(2).should == Money.new(106.20)
+      expect(Money.new(54.1754).round(2)).to eq(Money.new(54.18))
+      expect(Money.new(343.2050).round(2)).to eq(Money.new(343.21))
+      expect(Money.new(106.2038).round(2)).to eq(Money.new(106.20))
     end
 
     it "should implement standard rounding for 1 digit" do
-      Money.new(27.25).round(1).should == Money.new(27.3)
-      Money.new(27.45).round(1).should == Money.new(27.5)
-      Money.new(27.55).round(1).should == Money.new(27.6)
+      expect(Money.new(27.25).round(1)).to eq(Money.new(27.3))
+      expect(Money.new(27.45).round(1)).to eq(Money.new(27.5))
+      expect(Money.new(27.55).round(1)).to eq(Money.new(27.6))
     end
 
   end


### PR DESCRIPTION
Otherwise it'll never get done, might as well do it as I am playing in the code.

@davidcornu @sgnr as you are now pro in this codebase

From
```
$ rspec
-- create_table("money_records", {:force=>true})
   -> 0.0032s
....................................................................................................................................................................................

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/vagrant/src/money/spec/money_spec.rb:219:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.04948 seconds (files took 1.26 seconds to load)
180 examples, 0 failures
```

To:
```
$ rspec
-- create_table("money_records", {:force=>true})
   -> 0.0032s
....................................................................................................................................................................................

Finished in 0.0527 seconds (files took 1.25 seconds to load)
180 examples, 0 failures
```