### PR TITLE
Don't allow Money to represent -0.00

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -10,6 +10,7 @@ class Money
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
 
     @value = value_to_decimal(value).round(2)
+    @value = 0.to_d if @value.sign == BigDecimal::SIGN_NEGATIVE_ZERO 
     @cents = (@value * 100).to_i
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -54,6 +54,11 @@ describe "Money" do
     expect((Money.new(0.00) - Money.new(1.00))).to eq(Money.new("-1.00"))
   end
 
+  it "is never negative zero" do
+    expect(Money.new(-0.00).to_s).to eq("0.00")
+    expect((Money.new(0) * -1).to_s).to eq("0.00")
+  end
+
   it "inspects to a presentable string" do
     expect(@money.inspect).to eq("#<Money value:0.00>")
   end


### PR DESCRIPTION
Prevent storing negative zero in a Money object.

@Shopify/merchant-data please review