### PR TITLE
Money can be compared on the rhs of a Numeric.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -10,7 +10,7 @@ class Money
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
 
     @value = value_to_decimal(value).round(2)
-    @value = 0.to_d if @value.sign == BigDecimal::SIGN_NEGATIVE_ZERO 
+    @value = 0.to_d if @value.sign == BigDecimal::SIGN_NEGATIVE_ZERO
     @cents = (@value * 100).to_i
   end
 
@@ -51,6 +51,8 @@ class Money
   end
 
   class ReverseOperationProxy
+    include Comparable
+
     def initialize(value)
       @value = value
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -121,6 +121,26 @@ describe "Money" do
     expect((0.33 * Money.new(0.10))).to eq(Money.new(0.03))
   end
 
+  it "is less than a bigger integer" do
+    expect(Money.new(1)).to be < 2
+    expect(2).to be > Money.new(1)
+  end
+
+  it "is less than or equal to a bigger integer" do
+    expect(Money.new(1)).to be <= 2
+    expect(2).to be >= Money.new(1)
+  end
+
+  it "is greater than a lesser integer" do
+    expect(Money.new(2)).to be > 1
+    expect(1).to be < Money.new(2)
+  end
+
+  it "is greater than or equal to a lesser integer" do
+    expect(Money.new(2)).to be >= 1
+    expect(1).to be <= Money.new(2)
+  end
+
   it "raises if divided" do
     expect { Money.new(55.00) / 55 }.to raise_error
   end
@@ -367,14 +387,14 @@ describe "Money" do
       Money.parser = nil # reset
     end
   end
-  
+
   describe "round" do
-    
+
     it "rounds to 0 decimal places by default" do
       expect(Money.new(54.1).round).to eq(Money.new(54))
       expect(Money.new(54.5).round).to eq(Money.new(55))
     end
-    
+
     # Overview of standard vs. banker's rounding for next 4 specs:
     # http://www.xbeat.net/vbspeed/i_BankersRounding.htm
     it "implements standard rounding for 2 digits" do


### PR DESCRIPTION
The can of panda of accepting non-money instances for operations on money was opened a long time ago, and there is no going back. This PR does not worry about this fact, in fact it embraces it and just goes further.

r: @tjoyal @davidcornu