### PR TITLE
Allow sum of split in #allocate to be > 1.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -170,7 +170,6 @@ class Money
   #   Money.new(100, "USD").allocate([0.33,0.33,0.33]) #=> [Money.new(34), Money.new(33), Money.new(33)]
   def allocate(splits)
     allocations = splits.inject(0.0) {|sum, i| sum += i }
-    raise ArgumentError, "splits add to more than 100%" if allocations > 1.0
 
     left_over = cents
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -313,8 +313,8 @@ describe "Money" do
       expect(moneys[2].cents).to eq(33)
     end
 
-    specify "#allocate requires total to be less then 1" do
-      expect { Money.new(0.05).allocate([0.5,0.6]) }.to raise_error(ArgumentError)
+    specify "#allocate with total > 1" do
+      expect(Money.new(0.12).allocate([0.5, 0.6])).to eq([Money.new(0.06), Money.new(0.06)])
     end
   end
 


### PR DESCRIPTION
I need to split money in a line item discount, so I wanted to do something line `amount.split([3, 4])`, but that's not allowed. There seem to be no reason for this? The git history doesn't go that far ¯\_(ツ)_/¯.

r: @tjoyal @maximebedard 