### PR TITLE
Don't coerce Rationals to floats in allocate

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -316,6 +316,11 @@ describe "Money" do
     specify "#allocate requires total to be less then 1" do
       expect { Money.new(0.05).allocate([0.5,0.6]) }.to raise_error(ArgumentError)
     end
+
+    specify "#allocate will use rationals if provided" do
+      splits = [128400,20439,14589,14589,25936].map{ |num| Rational(num, 203953) } # sums to > 1 if converted to float
+      expect(Money.new(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
+    end
   end
 
   describe "split" do


### PR DESCRIPTION
Right now, if we attempt to pass `Rational` numbers to `allocate`, it will coerce those values into floats, sum them, and then raise if the resulting value is `> 1`. This is problematic for values who's rational representation sums to `1`, but when converted to float, the precision is lost and the value grows.

All of this code was pulled out of [RubyMoney/money#allocate](https://github.com/RubyMoney/money/blob/e8281aafd40af5d9b6d06cdc0d47703eb7d8cc34/lib/money/money.rb#L487-L501), and massaged to work with what we had already.

Running the new test before updating `#allocate` results in:
```
Failures:

  1) Money allocation #allocate will use rationals if provided
     Failure/Error: expect(Money.new(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
     ArgumentError:
       splits add to more than 100%
     # ./lib/money/money.rb:173:in `allocate'
     # ./spec/money_spec.rb:322:in `block (3 levels) in <top (required)>'
```

@Shopify/merchant-data @tjoyal @jduff for review