### PR TITLE
Explicitly convert rational with value_to_decimal

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -219,7 +219,7 @@ class Money
     left_over = cents
 
     amounts = splits.collect do |ratio|
-      (cents * ratio / allocations).floor.tap do |frac|
+      (value_to_decimal(cents * ratio) / allocations).floor.tap do |frac|
         left_over -= frac
       end
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -321,6 +321,13 @@ describe "Money" do
       splits = [128400,20439,14589,14589,25936].map{ |num| Rational(num, 203953) } # sums to > 1 if converted to float
       expect(Money.new(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
     end
+
+    specify "#allocate will convert rationals with high precision" do
+      ratios = [Rational(1, 1), Rational(0)]
+      expect(Money.new("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12"), Money.empty])
+      ratios = [Rational(1, 6), Rational(5, 6)]
+      expect(Money.new("3.00").allocate(ratios)).to eq([Money.new("0.50"), Money.new("2.50")])
+    end
   end
 
   describe "split" do


### PR DESCRIPTION
Allocating some values with a split of `[Rational(1), Rational(0)]` would allocate some pennies to the second party. This would result in dropped :scream: pennies and :fire: tests.

BigDecimal was using its own precision when performing the arithmetic in `amounts_from_splits` causing the mult/div to drop some significant digits. `value_to_decimal` uses `to_d(16)` on all rationals which is sufficiently large.

@Shopify/merchant-data 