### PR TITLE
Don't coerce rational splits to decimal

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -169,7 +169,11 @@ class Money
   #   Money.new(5, "USD").allocate([0.3,0.7)) #=> [Money.new(2), Money.new(3)]
   #   Money.new(100, "USD").allocate([0.33,0.33,0.33]) #=> [Money.new(34), Money.new(33), Money.new(33)]
   def allocate(splits)
-    allocations = splits.inject(0) { |sum, n| sum + value_to_decimal(n) }
+    if all_rational?(splits)
+      allocations = splits.inject(0) { |sum, n| sum + n }
+    else
+      allocations = splits.inject(0) { |sum, n| sum + value_to_decimal(n) }
+    end
 
     if (allocations - BigDecimal("1")) > Float::EPSILON
       raise ArgumentError, "splits add to more than 100%"
@@ -206,6 +210,10 @@ class Money
   end
 
   private
+
+  def all_rational?(splits)
+    splits.all? { |split| split.is_a?(Rational) }
+  end
 
   def value_to_decimal(num)
     if num.respond_to?(:to_d)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -313,7 +313,7 @@ describe "Money" do
       expect(moneys[2].cents).to eq(33)
     end
 
-    specify "#allocate requires total to be less then 1" do
+    specify "#allocate requires total to be less than 1" do
       expect { Money.new(0.05).allocate([0.5,0.6]) }.to raise_error(ArgumentError)
     end
 
@@ -327,6 +327,11 @@ describe "Money" do
       expect(Money.new("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12"), Money.empty])
       ratios = [Rational(1, 6), Rational(5, 6)]
       expect(Money.new("3.00").allocate(ratios)).to eq([Money.new("0.50"), Money.new("2.50")])
+    end
+
+    specify "#allocate doesn't raise with weird negative rational ratios" do
+      rate = Rational(-5, 1201)
+      expect { Money.new(1).allocate([rate, 1 - rate]) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
This was blowing up in production with "Splits add to more than 100%":

```
rate = Rational(-5, 1201)
Money.new(1).allocate([rate, 1-rate])
```

This PR ensures that we don't needlessly coerce rationals to decimal when checking if "splits add to more than 100%". 

I'm currently running a Shopify CI build against this branch to ensure no test failures.

@Shopify/merchant-data 