### PR TITLE
Add xml serilization methods

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: ruby-2.1.1
+    version: 2.3.0
 
 database:
   override:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -137,6 +137,14 @@ class Money
     to_s
   end
 
+  def to_xml(options = {})
+    to_s
+  end
+
+  def as_xml(*args)
+    to_s
+  end
+
   def abs
     Money.new(value.abs)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -153,6 +153,14 @@ describe "Money" do
     expect(Money.new(1.00).to_json).to eq("1.00")
   end
 
+  it "returns cents in to_xml" do
+    expect(Money.new(1.00).to_xml).to eq("1.00")
+  end
+
+  it "returns cents in as_xml" do
+    expect(Money.new(1.00).as_xml).to eq("1.00")
+  end
+
   it "supports absolute value" do
     expect(Money.new(-1.00).abs).to eq(Money.new(1.00))
   end


### PR DESCRIPTION
Allow Money objects to be serialized as xml.

@vignesh-vs-in @nick-mcdonald 