### PR TITLE
return nil when other not coercible

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -19,14 +19,17 @@ class Money
   end
 
   def <=>(other)
+    return nil unless other.respond_to?(:to_money)
     cents <=> other.to_money.cents
   end
 
   def +(other)
+    return nil unless other.respond_to?(:to_money)
     Money.new(value + other.to_money.value)
   end
 
   def -(other)
+    return nil unless other.respond_to?(:to_money)
     Money.new(value - other.to_money.value)
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -55,6 +55,14 @@ describe "Money" do
     expect((Money.new(0.00) - Money.new(1.00))).to eq(Money.new("-1.00"))
   end
 
+  it "is nil if other cannot coerce to money" do
+    expect((Money.new(5.00) - nil)).to eq(nil)
+  end
+
+  it "is nil if other cannot coerce to money" do
+    expect((Money.new(5.00) + nil)).to eq(nil)
+  end
+
   it "is never negative zero" do
     expect(Money.new(-0.00).to_s).to eq("0.00")
     expect((Money.new(0) * -1).to_s).to eq("0.00")
@@ -238,6 +246,10 @@ describe "Money" do
       expect((1 <=> @money)).to eq(0)
       expect((2 <=> @money)).to eq(1)
       expect((0.5 <=> @money)).to eq(-1)
+    end
+
+    it "<=> is nil if other cannot coerce to money" do
+      expect((@money <=> nil)).to eq(nil)
     end
 
     it "have the same hash value as $1" do


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/issues/84192

When there are searches like `{% assign sorted_result = search.results|sort:'price' %}` we wind up at https://github.com/Shopify/liquid/blob/master/lib/liquid/standardfilters.rb#L128

```
def sort(input, property = nil)
  ary = InputIterator.new(input)
  if property.nil?
    ary.sort
  elsif ary.empty? # The next two cases assume a non-empty array.
    []
  elsif ary.first.respond_to?(:[]) && !ary.first[property].nil?
    ary.sort { |a, b| a[property] <=> b[property] }
  end
end
```

Consider a search where the results are a `ProductDrop` and an `ArticleDrop`. The `ProductDrop` will respond to `price` but the `ArticleDrop` will not. When we run the overloaded operator https://github.com/Shopify/money/blob/master/lib/money/money.rb#L22 we'll try `to_money` and create a `NoMethodError`. 

Instead, we can detect the other variable is incompatible and return nil.

One thought though, just returning nil probably just pushes the exception a layer higher - would it make more sense to have a coercion exception which Money can throw?

For example

```
[1] pry(main)> 1.to_money
=> #<Money value:1.00>
[2] pry(main)> 1.to_money + nil
NoMethodError: undefined method `to_money' for nil:NilClass
```

seems pretty bad, there is no information, no chance of the code continuing

consider what happens when adding to a regular integer

```
[3] pry(main)> 1 + nil
TypeError: nil can't be coerced into Fixnum
```

Should we also have such an error for Money, or is `nil` an acceptable result for adding nil to money?

@cplehm @jahfer @maximebedard cc @Thibaut 