### PR TITLE
raise type error if other incompatible

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -19,14 +19,17 @@ class Money
   end
 
   def <=>(other)
+    raise TypeError, "#{other.class.name} can't be coerced into Money" unless other.respond_to?(:to_money)
     cents <=> other.to_money.cents
   end
 
   def +(other)
+    raise TypeError, "#{other.class.name} can't be coerced into Money" unless other.respond_to?(:to_money)
     Money.new(value + other.to_money.value)
   end
 
   def -(other)
+    raise TypeError, "#{other.class.name} can't be coerced into Money" unless other.respond_to?(:to_money)
     Money.new(value - other.to_money.value)
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -39,12 +39,20 @@ describe "Money" do
     expect((Money.new(1.51) + Money.new(3.49))).to eq(Money.new(5.00))
   end
 
+  it "raises error if added other is not compatible" do
+    expect{ Money.new(5.00) + nil }.to raise_error
+  end
+
   it "is able to add $0 + $0" do
     expect((Money.new + Money.new)).to eq(Money.new)
   end
 
   it "is subtractable" do
     expect((Money.new(5.00) - Money.new(3.49))).to eq(Money.new(1.51))
+  end
+
+  it "raises error if subtracted other is not compatible" do
+    expect{ Money.new(5.00) - nil }.to raise_error
   end
 
   it "is subtractable to $0" do
@@ -238,6 +246,10 @@ describe "Money" do
       expect((1 <=> @money)).to eq(0)
       expect((2 <=> @money)).to eq(1)
       expect((0.5 <=> @money)).to eq(-1)
+    end
+
+    it "raises error if compared other is not compatible" do
+      expect{ Money.new(5.00) <=> nil }.to raise_error
     end
 
     it "have the same hash value as $1" do


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/issues/84192

When there are searches like `{% assign sorted_result = search.results|sort:'price' %}` we wind up at https://github.com/Shopify/liquid/blob/master/lib/liquid/standardfilters.rb#L128

```
def sort(input, property = nil)
  ary = InputIterator.new(input)
  if property.nil?
    ary.sort
  elsif ary.empty? # The next two cases assume a non-empty array.
    []
  elsif ary.first.respond_to?(:[]) && !ary.first[property].nil?
    ary.sort { |a, b| a[property] <=> b[property] }
  end
end
```

Consider a search where the results are a `ProductDrop` and an `ArticleDrop`. The `ProductDrop` will respond to `price` but the `ArticleDrop` will not. When we run the overloaded operator https://github.com/Shopify/money/blob/master/lib/money/money.rb#L22 we'll try `to_money` and create a `NoMethodError`. 

This doesn't provide any particular information about the error. In Ruby, a much better error is returned

```
irb(main):001:0> 1 + nil
TypeError: nil can't be coerced into Fixnum
```

Let's do the same!

@rafaelfranca @stephenminded cc @Thibaut 