### PR TITLE
Revert "Create xml in to_xml if options present"

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -141,11 +141,11 @@ class Money
   end
 
   def to_xml(options = {})
-    if options.key?(:builder) && options.key?(:root)
-      options[:builder].tag!(options[:root], to_s, type: "decimal")
-    else
-      to_s
-    end
+    to_s
+  end
+
+  def as_xml(*args)
+    to_s
   end
 
   def abs

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
-require 'builder'
 
 describe "Money" do
 
@@ -166,14 +165,8 @@ describe "Money" do
     expect(Money.new(1.00).to_xml).to eq("1.00")
   end
 
-  it "returns xml in to_xml with options present" do
-    options = {
-      root: "price",
-      format: "xml",
-      builder: Builder::XmlMarkup.new,
-      skip_instruct: true
-    }
-    expect(Money.new(1.00).to_xml(options)).to eq("<price type=\"decimal\">1.00</price>")
+  it "returns cents in as_xml" do
+    expect(Money.new(1.00).as_xml).to eq("1.00")
   end
 
   it "supports absolute value" do


### PR DESCRIPTION
Reverts Shopify/money#33

This change, which apparently we don't need in core, is preventing the gem from being updated. Let's back off on this change until there is a clear need.

@vignesh-vs-in @cplehm cc @stephenminded 