### PR TITLE
Revert "Add xml serilization methods"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: ruby-2.1.1
+    version: 2.3.0
 
 database:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.3.0
+    version: ruby-2.1.1
 
 database:
   override:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -140,14 +140,6 @@ class Money
     to_s
   end
 
-  def to_xml(options = {})
-    to_s
-  end
-
-  def as_xml(*args)
-    to_s
-  end
-
   def abs
     Money.new(value.abs)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -161,14 +161,6 @@ describe "Money" do
     expect(Money.new(1.00).to_json).to eq("1.00")
   end
 
-  it "returns cents in to_xml" do
-    expect(Money.new(1.00).to_xml).to eq("1.00")
-  end
-
-  it "returns cents in as_xml" do
-    expect(Money.new(1.00).as_xml).to eq("1.00")
-  end
-
   it "supports absolute value" do
     expect(Money.new(-1.00).abs).to eq(Money.new(1.00))
   end


### PR DESCRIPTION
Reverts Shopify/money#32

https://buildkite.com/shopify/shopify-branches/builds/172534#2b32f6da-bd13-4ae6-bdac-e31c808b4cc1

^ @vignesh-vs-in @cplehm cc @stephenminded still getting a bunch of failures, I think we need to revert this too, which then gets us back to the last version which could be cleanly used with Shopify core