### PR TITLE
Multiply using rationals

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -34,7 +34,7 @@ class Money
   end
 
   def *(numeric)
-    Money.new(value * numeric)
+    Money.new(value.to_r * numeric)
   end
 
   def /(numeric)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -114,9 +114,19 @@ describe "Money" do
     expect((0.50 * Money.new(1.00))).to eq(Money.new(0.50))
   end
 
+  it "is multipliable by a rational" do
+    expect((Money.new(3.3) * Rational(1, 12))).to eq(Money.new(0.28))
+    expect((Rational(1, 12) * Money.new(3.3))).to eq(Money.new(0.28))
+  end
+
   it "is multipliable by a repeatable floating point number" do
     expect((Money.new(24.00) * (1 / 30.0))).to eq(Money.new(0.80))
     expect(((1 / 30.0) * Money.new(24.00))).to eq(Money.new(0.80))
+  end
+
+  it "is multipliable by a repeatable floating point number where the floating point error rounds down" do
+    expect((Money.new(3.3) * (1.0 / 12))).to eq(Money.new(0.28))
+    expect(((1.0 / 12) * Money.new(3.3))).to eq(Money.new(0.28))
   end
 
   it "rounds multiplication result with fractional penny of 5 or higher up" do


### PR DESCRIPTION
## Problem

Multiplying a `Money` object by a rational, or repeatable floating point, can cause inaccurate rounding due to lost precision. In the following example `3.3 x (1/12)` should round to `0.28`.

## Changes

### Multiplying by a rational

#### Before
- Multiplying the finite `Money.new(3.3)` by the infinite `Rational(1, 12)` returns a lossy `BigDecimal` of `0.2749999999`.
- `Money.new` rounds this lossy value down to the incorrect `0.27`.

#### After
- Multiplying the finite `Money.new(3.3)` by the infinite `Rational(1, 12)` converts the `Money` to  `Rational(33, 10)`, resulting in the precise `Rational(33/120)`.
- `Money.new` rounds this pure value to the correct `0.28`.

### Multiplying by a repeatable floating point

#### Before
- Multiplying the finite `Money.new(3.3)` by the lossy `1.0/12` returns a lossy `BigDecimal` of `0.2749999999`.
- `Money.new` calls `to_d` on this lossy value  which [stays](https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/util.rb#L93-L99) as `BigDecimal` of `0.2749999999`.
- `round(2)` rounds down to the incorrect `0.27`.

#### After
- Multiplying the finite `Money.new(3.3)` by the lossy `1.0/12` converts the `Money` to  `Rational(33, 10)`, resulting in the lossy `Float` of `0.27499999999999997`.
- `Money.new` calls `to_d` on this lossy value which [becomes](https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/util.rb#L23-L42)  `BigDecimal` of `0.275`.
- `round(2)` rounds up to the correct `0.28`.
