### PR TITLE
Fix parsing for digits with more than 2 decimals

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -5,29 +5,29 @@ class MoneyParser
   def self.parse(input)
     new.parse(input)
   end
-  
+
   def parse(input)
     Money.new(extract_money(input))
   end
-  
+
   private
   def extract_money(input)
     return ZERO_MONEY if input.to_s.empty?
-    
+
     amount = input.scan(/\-?[\d\.\,]+/).first
-            
+
     return ZERO_MONEY if amount.nil?
-    
-    # Convert 0.123 or 0,123 into what will be parsed as a decimal amount 0.12 or 0.13
-    amount.gsub!(/^(-)?(0[,.]\d\d)\d+$/, '\1\2')
-            
+
+    # Convert amount with more than 3 decimals to amount with 2 decimals
+    amount.gsub!(/^(-)?(\d{1,}[,.]\d\d)[1-9]+$/, '\1\2')
+
     segments = amount.scan(/^(.*?)(?:[\.\,](\d{1,2}))?$/).first
-        
-    return ZERO_MONEY if segments.empty?    
-    
+
+    return ZERO_MONEY if segments.empty?
+
     amount   = segments[0].gsub(/[^-\d]/, '')
     decimals = segments[1].to_s.ljust(2, '0')
-    
+
     "#{amount}.#{decimals}"
   end
 end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -5,43 +5,47 @@ describe MoneyParser do
     before(:each) do
       @parser = MoneyParser.new
     end
-  
+
     it "parses an empty string to $0" do
       expect(@parser.parse("")).to eq(Money.new)
     end
-  
+
     it "parses an invalid string to $0" do
       expect(@parser.parse("no money")).to eq(Money.new)
     end
-  
+
     it "parses a single digit integer string" do
       expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a double digit integer string" do
       expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
-  
+
     it "parses an integer string amount with a leading $" do
       expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a float string amount" do
       expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
-  
+
+    it "parses a float string amount with 3 decimals" do
+      expect(@parser.parse("1.372")).to eq(Money.new(1.37))
+    end
+
     it "parses a float string amount with a leading $" do
       expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
-  
+
     it "parses a float string with a single digit after the decimal" do
       expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
-  
+
     it "parses a float string with two digits after the decimal" do
       expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
-  
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -61,7 +65,7 @@ describe MoneyParser do
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
@@ -73,19 +77,19 @@ describe MoneyParser do
     it "parses a negative cents amount" do
       expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
-    
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple leading - signs" do
       expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple - signs" do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
@@ -95,7 +99,7 @@ describe MoneyParser do
     before(:each) do
       @parser = MoneyParser.new
     end
-    
+
     it "parses dollar amount $1,00 with leading $" do
       expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
@@ -103,7 +107,7 @@ describe MoneyParser do
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
       expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
-    
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -111,81 +115,81 @@ describe MoneyParser do
     it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
-    
+
     it "parses thousands amount" do
       expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
-    
+
     it "parses negative hundreds amount" do
       expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
-    
+
     it "parses positive hundreds amount" do
       expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
-    
+
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
-    
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
-  
+
   describe "parsing of decimal cents amounts from 0 to 10" do
     before(:each) do
       @parser = MoneyParser.new
     end
-    
+
     it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
-    
+
     it "parses 50.1" do
       expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
-    
+
     it "parses 50.2" do
       expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
-    
+
     it "parses 50.3" do
       expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
-    
+
     it "parses 50.4" do
       expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
-    
+
     it "parses 50.5" do
       expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
-    
+
     it "parses 50.6" do
       expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
-    
+
     it "parses 50.7" do
       expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
-    
+
     it "parses 50.8" do
       expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
-    
+
     it "parses 50.9" do
       expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
-    
+
     it "parses 50.10" do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end


### PR DESCRIPTION
Hi, it is my first contribution to an open source project so let me know if there is other things I can do to make this change approved :)

## Problem
Issue #13 

```
irb(main):001:0> require 'money'
=> true
irb(main):002:0> "1.11111111".to_money
=> #<Money value:111111111.00>
irb(main):003:0> "1.11111111".to_money.to_f
=> 111111111.0
```

## Changes
Regex in MoneyParser now matched and substitute digits with more than 2 decimals to digits with 2 decimals => **1.1234** becomes **1.23**