### PR TITLE
Introduce Money.from_amount for compatibility with RubyMoney

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem 'rdoc'
-  gem "rspec", "~> 3.2.0"
+  gem "rspec", "~> 3.2"
   gem "bundler", "~> 1.5"
   gem "jeweler", "~> 1.6.0"
   gem "simplecov", ">= 0"

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -6,11 +6,11 @@ class Money
 
   attr_reader :value, :cents
 
-  def self.from_amount(value)
-    new(value)
+  class << self
+    alias_method :from_amount, :new
   end
 
-  def initialize(value = 0)
+  def initialize(value = 0, _currency = nil)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
 
     @value = value_to_decimal(value).round(2)
@@ -104,7 +104,7 @@ class Money
   end
 
   def self.empty
-    Money.new
+    Money.new(0)
   end
 
   def self.from_cents(cents)
@@ -270,8 +270,10 @@ class Money
   def value_to_decimal(num)
     if num.respond_to?(:to_d)
       num.is_a?(Rational) ? num.to_d(16) : num.to_d
-    else
+    elsif num.is_a?(Money)
       BigDecimal.new(num.to_s)
+    else
+      raise ArgumentError, "value_to_decimal could not parse #{num.inspect}"
     end
   end
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -6,6 +6,10 @@ class Money
 
   attr_reader :value, :cents
 
+  def self.from_amount(value)
+    new(value)
+  end
+
   def initialize(value = 0)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -39,7 +39,7 @@ describe "Money" do
   end
 
   it "raises error if added other is not compatible" do
-    expect{ Money.new(5.00) + nil }.to raise_error
+    expect{ Money.new(5.00) + nil }.to raise_error(TypeError)
   end
 
   it "is able to add $0 + $0" do
@@ -51,7 +51,7 @@ describe "Money" do
   end
 
   it "raises error if subtracted other is not compatible" do
-    expect{ Money.new(5.00) - nil }.to raise_error
+    expect{ Money.new(5.00) - nil }.to raise_error(TypeError)
   end
 
   it "is subtractable to $0" do
@@ -160,7 +160,7 @@ describe "Money" do
   end
 
   it "raises if divided" do
-    expect { Money.new(55.00) / 55 }.to raise_error
+    expect { Money.new(55.00) / 55 }.to raise_error(RuntimeError)
   end
 
   it "returns cents in to_liquid" do
@@ -196,7 +196,7 @@ describe "Money" do
   end
 
   it "raises when constructed with a NaN value" do
-    expect { Money.new( 0.0 / 0) }.to raise_error
+    expect { Money.new( 0.0 / 0) }.to raise_error(ArgumentError)
   end
 
   it "is comparable with non-money objects" do
@@ -244,7 +244,7 @@ describe "Money" do
     end
 
     it "raises error if compared other is not compatible" do
-      expect{ Money.new(5.00) <=> nil }.to raise_error
+      expect{ Money.new(5.00) <=> nil }.to raise_error(TypeError)
     end
 
     it "have the same hash value as $1" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -485,4 +485,16 @@ describe "Money" do
     end
 
   end
+
+  describe "from_amount quacks like RubyMoney" do
+    it "accepts numeric values" do
+      expect(Money.from_amount(1)).to eq Money.from_cents(1_00)
+      expect(Money.from_amount(1.0)).to eq Money.from_cents(1_00)
+      expect(Money.from_amount("1".to_d)).to eq Money.from_cents(1_00)
+    end
+
+    it "raises ArgumentError with unsupported argument" do
+      expect { Money.from_amount(Object.new) }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -493,6 +493,14 @@ describe "Money" do
       expect(Money.from_amount("1".to_d)).to eq Money.from_cents(1_00)
     end
 
+    it "accepts string values" do
+      expect(Money.from_amount("1")).to eq Money.from_cents(1_00)
+    end
+
+    it "accepts an optional currency parameter" do
+      expect { Money.from_amount(1, "CAD") }.to_not raise_error
+    end
+
     it "raises ArgumentError with unsupported argument" do
       expect { Money.from_amount(Object.new) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
…and by extension offsite_payments. 

We use this gem in Shopify instead of `money` on Rubygems. The API's were similar enough until https://github.com/activemerchant/offsite_payments/pull/217 introduced a change which broke upgrading offsite_payments in Shopify. This PR aims to restore compatibility between ShopifyMoney and RubyMoney to unblock ourselves until a [better solution](https://github.com/Shopify/shopify/issues/95949) is found.

ShopifyMoney.new calls `#value_to_decimal` to either cast a Numeric object to BigDecimal, or have BigDecimal parse the input value. RubyMoney [does something similar for .from_amount](https://github.com/RubyMoney/money/blob/557561ef7259b8d2ab6a3603d0a5335e90842644/lib/money/money.rb#L216-L236).