### PR TITLE
from_amount handle nil

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -268,7 +268,9 @@ class Money
   end
 
   def value_to_decimal(num)
-    if num.respond_to?(:to_d)
+    if num.nil?
+      BigDecimal.new(0)
+    elsif num.respond_to?(:to_d)
       num.is_a?(Rational) ? num.to_d(16) : num.to_d
     elsif num.is_a?(Money)
       BigDecimal.new(num.to_s)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -497,6 +497,10 @@ describe "Money" do
       expect(Money.from_amount("1")).to eq Money.from_cents(1_00)
     end
 
+    it "accepts nil values" do
+      expect(Money.from_amount(nil)).to eq Money.from_cents(0)
+    end
+
     it "accepts an optional currency parameter" do
       expect { Money.from_amount(1, "CAD") }.to_not raise_error
     end


### PR DESCRIPTION
**Why**

nils to the `from_amount` are expected to be 0. This https://github.com/Shopify/money/pull/44 introduced a change in behavior

**What**
- regression test
- update `value_to_decimal`