### PR TITLE
adds #to_d support to Money object

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -128,6 +128,10 @@ class Money
     value.to_f
   end
 
+  def to_d
+    value
+  end
+
   def to_s
     sprintf("%.2f", value.to_f)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -179,6 +179,10 @@ describe "Money" do
     expect(Money.new(1.50).to_i).to eq(1)
   end
 
+  it "supports to_d" do
+    expect(Money.new(1).to_d).to eq(BigDecimal(1))
+  end
+
   it "supports to_f" do
     expect(Money.new(1.50).to_f.to_s).to eq("1.5")
   end


### PR DESCRIPTION
Add `#to_d` instance method to `Money`, returns internal decimal representation.