### PR TITLE
Memoize and freeze Money.empty

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -104,7 +104,7 @@ class Money
   end
 
   def self.empty
-    Money.new(0)
+    @@empty ||= Money.new(0).freeze
   end
 
   def self.from_cents(cents)


### PR DESCRIPTION
### Context

After some profiling, some API endpoints making heavy use of Money objects spend a big chunk of their time in the money gem:
![capture d ecran 2017-04-27 a 16 03 59](https://cloud.githubusercontent.com/assets/19192189/25487007/3baa1722-2b63-11e7-9da5-0251a24681db.png)

### Perf investigation

It turns out instantiating a `Money` instance is quite costly. There is a lot of parsing happening even for simple known cases. I ran the following simple benchmark:

```ruby
Benchmark.ips do |x|
  x.report('BigDecimal.new(int)') { BigDecimal(0) }
  x.report('BigDecimal.new(string)') { BigDecimal('0') }
  x.report('Money.new(int)') { Money.new(0) }
  x.report('Money.new(string)') { Money.new('0') }
end
```

```
Warming up --------------------------------------
 BigDecimal.new(int)    74.779k i/100ms
BigDecimal.new(string)
                       104.490k i/100ms
      Money.new(int)    26.061k i/100ms
   Money.new(string)    28.897k i/100ms
Calculating -------------------------------------
 BigDecimal.new(int)      1.029M (± 5.0%) i/s -      5.160M in   5.028362s
BigDecimal.new(string)
                          1.588M (± 5.8%) i/s -      7.941M in   5.021061s
      Money.new(int)    297.115k (± 4.7%) i/s -      1.485M in   5.012021s
   Money.new(string)    330.913k (± 4.0%) i/s -      1.676M in   5.073410s
```

So money is adding a 5-8X overhead over just instantiating a BigDecimal.

### Quick win

I plan to investigate this further to see if I can improve that situation, but first I figured `Money.empty` is used quite often in our code base. So since AFAICT `Money` instances are immutable, I see no reasons not to memoize it. That should save quite a lot.

@DazWorrall @wvanbergen @bdewater @elfassy @pi3r for review please.