### PR TITLE
Yaml backward compat

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -281,6 +281,8 @@ class Money
   DECIMAL_ZERO = BigDecimal.new(0).freeze
   def value_to_decimal(num)
     case num
+    when BigDecimal
+      num
     when nil
       DECIMAL_ZERO
     when Money

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -29,6 +29,10 @@ class Money
     freeze
   end
 
+  def init_with(coder)
+    initialize(coder.map['value'.freeze])
+  end
+
   def -@
     Money.new(-value)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -509,4 +509,28 @@ describe "Money" do
       expect { Money.from_amount(Object.new) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "YAML loading of old versions" do
+    it "accepts BigDecimal values" do
+      money = YAML.load(<<~EOS)
+        ---
+        !ruby/object:Money
+          value: !ruby/object:BigDecimal 18:0.75E3
+          cents: 75000
+      EOS
+      expect(money).to be == Money.new(750)
+      expect(money.value).to be_a BigDecimal
+    end
+
+    it "accepts old float values..." do
+      money = YAML.load(<<~EOS)
+        ---
+        !ruby/object:Money
+          value: 750.00
+          cents: 75000
+      EOS
+      expect(money).to be == Money.new(750)
+      expect(money.value).to be_a BigDecimal
+    end
+  end
 end


### PR DESCRIPTION
Following https://github.com/Shopify/money/pull/51 it turns out a long time ago `value` used to be a Float in some case.

As a result `Money` instances serialized as YAML at that time look like this:

```yaml
!ruby/object:Money
  value: 750.00
  cents: 75000
```

Instead of this

```yaml
!ruby/object:Money
  value: !ruby/object:BigDecimal 18:0.75E3
  cents: 75000
```

Since YAML by allocates the instance and set the instance variables directly, those floats don't get casted at all, and the previous assumption that the `value` attribute is always a `BigDecimal` is wrong.

This PR ensure we properly cast the `value` when we restore money instances.

@wvanbergen @DazWorrall for review please.