### PR TITLE
Money.new to use super instead of from_amount

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -7,17 +7,19 @@ class Money
   attr_reader :value, :cents
 
   class << self
-    alias_method :from_amount, :new
-
     def new(value = 0, _currency = nil)
       if value == 0
-        @empty ||= from_amount(0)
+        @empty ||= super(0)
       else
-        from_amount(value, _currency)
+        super(value, _currency)
       end
     end
 
-    alias_method :empty, :new
+    def empty
+      new(0)
+    end
+
+    alias_method :from_amount, :new
   end
 
   def initialize(value = 0, _currency = nil)


### PR DESCRIPTION
# What
Change new patch introduced https://github.com/Shopify/money/pull/50 to use `super` instead of `from_amount`

# Why
`from_amount` was introduced with the a specific purpose of delegating to `new`, and therefore should not be called within it. Right now `Money.from_amount(0)` would not use the memoized `@empty` value. Moreover `super` is preferred to using an `alias`. It is also incorrect to alias `empty` to `new` since `empty` should not accept any attributes.