### PR TITLE
Revert "Revert "adds #to_d support to Money object""

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -141,6 +141,10 @@ class Money
     value.to_f
   end
 
+  def to_d
+    value
+  end
+
   def to_s
     sprintf("%.2f", value.to_f)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -179,6 +179,10 @@ describe "Money" do
     expect(Money.new(1.50).to_i).to eq(1)
   end
 
+  it "supports to_d" do
+    expect(Money.new(1.29).to_d).to eq(BigDecimal.new('1.29'))
+  end
+
   it "supports to_f" do
     expect(Money.new(1.50).to_f.to_s).to eq("1.5")
   end


### PR DESCRIPTION
Reverts Shopify/money#47

adds support for `to_d` to money objects