### PR TITLE
Add conversion to string in Money#parse if input is not a string

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -7,7 +7,7 @@ class MoneyParser
   end
   
   def parse(input)
-    Money.new(extract_money(input))
+    Money.new(extract_money(input.to_s))
   end
   
   private

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -190,4 +190,32 @@ describe MoneyParser do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end
+
+  describe "parsing of fixnum" do
+    before(:each) do
+      @parser = MoneyParser.new
+    end
+    
+    it "parses 1" do
+      expect(@parser.parse(1)).to eq(Money.new(1))
+    end
+
+    it "parses 50" do
+      expect(@parser.parse(50)).to eq(Money.new(50))
+    end
+  end
+
+  describe "parsing of float" do
+    before(:each) do
+      @parser = MoneyParser.new
+    end
+
+    it "parses 1.00" do
+      expect(@parser.parse(1.00)).to eq(Money.new(1.00))
+    end
+
+    it "parses 1.32" do
+      expect(@parser.parse(1.32)).to eq(Money.new(1.32))
+    end   
+  end
 end


### PR DESCRIPTION
**Why**

Inputs to `Money#parse` throw an error if they are anything besides a string. It would make sense for something like `Money.parse(1)` to work.

**What**

Added a simple cast to string if the input on parse is anything besides a string.