### PR TITLE
nicer requires

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,6 +1,6 @@
-require File.dirname(__FILE__) + '/money/money'
-require File.dirname(__FILE__) + '/money/money_parser'
-require File.dirname(__FILE__) + '/money/accounting_money_parser'
-require File.dirname(__FILE__) + '/money/core_extensions'
-require File.dirname(__FILE__) + '/money_accessor'
-require File.dirname(__FILE__) + '/money_column' if defined?(Rails)
+require_relative 'money/money'
+require_relative 'money/money_parser'
+require_relative 'money/accounting_money_parser'
+require_relative 'money/core_extensions'
+require_relative 'money_accessor'
+require_relative 'money_column' if defined?(Rails)

--- a/lib/money_column.rb
+++ b/lib/money_column.rb
@@ -1,2 +1,2 @@
-require File.dirname(__FILE__) + '/money_column/active_record_hooks'
-require File.dirname(__FILE__) + '/money_column/railtie'
+require_relative 'money_column/active_record_hooks'
+require_relative 'money_column/railtie'

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe AccountingMoneyParser do
   describe "parsing of amounts with period decimal separator" do

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 shared_examples_for "an object supporting to_money" do
   it "supports to_money" do

--- a/spec/money_accessor_spec.rb
+++ b/spec/money_accessor_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 class NormalObject
   include MoneyAccessor

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 class MoneyRecord < ActiveRecord::Base
   money_column :price

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe MoneyParser do
   describe "parsing of amounts with period decimal separator" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe "Money" do
 


### PR DESCRIPTION
# What 
Use `require` and `require_relative`

# Why
Easier to read and `require_relative` is the correct way to require since ruby 1.9.3

In tests we can use `require 'spec_helper'` directly since /spec files are added it to the load path `$LOAD_PATH.unshift(File.dirname(__FILE__))`