### PR TITLE
Add `Money.with_currency` similar to Rails' `Time.use_zone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,27 @@ currency.disambiguate_symbol #=> 'US$'
 
 ### Default Currency
 
-By default `Money` defaults to Money::NullCurrency as its currency. This can be overwritten
-using:
+By default `Money` defaults to Money::NullCurrency as its currency. This is a 
+global variable that can be changed using:
 
 ``` ruby
 Money.default_currency = Money::Currency.new("USD")
 ```
 
-If you use Rails, then `environment.rb` is a very good place to put this.
+In web apps you might want to set the default currency on a per request basis.
+In Rails you can do this with an around action, for example:
+
+```ruby
+class ApplicationController < ActionController::Base
+  around_action :set_currency
+
+  private
+
+  def set_currency
+    Money.with_currency(current_shop.currency) { yield }
+  end
+end
+```
 
 ### Currency Minor Units
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -23,8 +23,8 @@ class Money
     end
     alias_method :empty, :zero
 
-    def parse(input, _currency = nil)
-      parser.parse(input)
+    def parse(input, currency = nil)
+      parser.parse(input, currency)
     end
 
     def from_cents(cents, currency = nil)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -7,7 +7,7 @@ class Money
     attr_accessor :parser, :default_currency
 
     def new(value = 0, currency = nil)
-      currency ||= default_currency
+      currency ||= current_currency || default_currency
 
       if value == 0
         @@zero_money ||= {}
@@ -35,6 +35,28 @@ class Money
       currency = Helpers.value_to_currency(currency_iso)
       value = Helpers.value_to_decimal(subunits) / currency.subunit_to_unit
       new(value, currency)
+    end
+
+    def current_currency
+      Thread.current[:money_currency]
+    end
+
+    def current_currency=(currency)
+      Thread.current[:money_currency] = currency
+    end
+
+    # Set Money.default_currency inside the supplied block, resets it to
+    # the previous value when done to prevent leaking state. Similar to
+    # I18n.with_locale and ActiveSupport's Time.use_zone. This won't affect
+    # instances being created with explicitly set currency.
+    def with_currency(new_currency)
+      begin
+        old_currency = Money.current_currency
+        Money.current_currency = new_currency
+        yield
+      ensure
+        Money.current_currency = old_currency
+      end
     end
 
     def default_settings

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 shared_examples_for "an object supporting to_money" do
   it "supports to_money" do
     expect(@value.to_money).to eq(@money)
+    expect(@value.to_money('CAD').currency).to eq(Money::Currency.find!('CAD'))
   end
 end
 
@@ -28,7 +29,6 @@ describe String do
   before(:each) do
     @value = "1.23"
     @money = Money.new(@value)
-    @currency = Money::Currency.new(:usd)
   end
 
   it_should_behave_like "an object supporting to_money"

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -632,4 +632,47 @@ describe "Money" do
       Money.deprecate('ok')
     end
   end
+
+  describe '#use_currency' do
+    it "allows setting the implicit default currency for a block scope" do
+      money = nil
+      Money.with_currency('CAD') do
+        money = Money.new(1.00)
+      end
+
+      expect(money.currency.iso_code).to eq('CAD')
+    end
+
+    it "does not use the currency for a block scope when explicitly set" do
+      money = nil
+      Money.with_currency('CAD') do
+        money = Money.new(1.00, 'USD')
+      end
+
+      expect(money.currency.iso_code).to eq('USD')
+    end
+
+    context "with .default_currency set" do
+      before(:each) { Money.default_currency = Money::Currency.new('EUR') }
+      after(:each) { Money.default_currency = Money::NullCurrency }
+
+      it "can be nested and falls back to default_currency outside of the blocks" do
+        money2, money3 = nil
+
+        money1 = Money.new(1.00)
+        Money.with_currency('CAD') do
+          Money.with_currency('USD') do
+            money2 = Money.new(1.00)
+          end
+          money3 = Money.new(1.00)
+        end
+        money4 = Money.new(1.00)
+
+        expect(money1.currency.iso_code).to eq('EUR')
+        expect(money2.currency.iso_code).to eq('USD')
+        expect(money3.currency.iso_code).to eq('CAD')
+        expect(money4.currency.iso_code).to eq('EUR')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows to set the implicit default currency in a block scope, without having to set it explicitly inside the scope every time a new money object is created.