### PR TITLE
encode_with currency for simple serialization

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -57,7 +57,7 @@ class Money
   end
 
   def encode_with(coder)
-    coder['value'] = @value
+    coder['value'] = @value.to_s('F')
     coder['currency'] = @currency.iso_code
   end
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -53,7 +53,12 @@ class Money
   end
 
   def init_with(coder)
-    initialize(coder.map['value'], coder.map['currency'])
+    initialize(coder['value'], coder['currency'])
+  end
+
+  def encode_with(coder)
+    coder['value'] = @value
+    coder['currency'] = @currency.iso_code
   end
 
   def -@

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -583,17 +583,18 @@ describe "Money" do
     end
   end
 
-  describe "YAML loading of old versions" do
+  describe "YAML serialization" do
+    it "accepts values with currencies" do
+      money = YAML.dump(Money.new(750, 'usd'))
+      expect(money).to eq("--- !ruby/object:Money\nvalue: !ruby/object:BigDecimal 18:0.75E3\ncurrency: USD\n")
+    end
+  end
+
+  describe "YAML deserialization" do
 
     it "accepts values with currencies" do
-      money = YAML.load(<<~EOS)
-        ---
-        !ruby/object:Money
-          value: !ruby/object:BigDecimal 18:0.75E3
-          cents: 75000
-          currency: 'usd'
-      EOS
-      expect(money).to be == Money.new(750, 'usd')
+      money = YAML.load("--- !ruby/object:Money\nvalue: !ruby/object:BigDecimal 18:0.75E3\ncurrency: USD\n")
+      expect(money).to eq(Money.new(750, 'usd'))
     end
 
     it "accepts BigDecimal values" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -586,14 +586,14 @@ describe "Money" do
   describe "YAML serialization" do
     it "accepts values with currencies" do
       money = YAML.dump(Money.new(750, 'usd'))
-      expect(money).to eq("--- !ruby/object:Money\nvalue: !ruby/object:BigDecimal 18:0.75E3\ncurrency: USD\n")
+      expect(money).to eq("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: USD\n")
     end
   end
 
   describe "YAML deserialization" do
 
     it "accepts values with currencies" do
-      money = YAML.load("--- !ruby/object:Money\nvalue: !ruby/object:BigDecimal 18:0.75E3\ncurrency: USD\n")
+      money = YAML.load("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: USD\n")
       expect(money).to eq(Money.new(750, 'usd'))
     end
 


### PR DESCRIPTION
# Why
There's no need to serialize complex objects such as the currency objects, only the iso_code string is needed. 
- use less resources (no need to store all the currency data on every record)
- easier for humans to read db records
- old gem versions will be able to deserialize the new format (otherwise might raise Currency class not found), useful for phased deploys

# What
- use `encode_with` to specify how to serialize the money object and `init_with` to deserialize
- serialize currency as the `iso_code` string