### PR TITLE
Round value to the correct number of minor units

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -47,7 +47,7 @@ class Money
   def initialize(value = 0, currency = nil)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
     @currency = Helpers.value_to_currency(currency)
-    @value = Helpers.value_to_decimal(value).round(2)
+    @value = Helpers.value_to_decimal(value).round(@currency.minor_units)
     @cents = (@value * 100).to_i
     freeze
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -330,6 +330,13 @@ describe "Money" do
 
   end
 
+  describe "value" do
+    it "rounds to the number of minor units provided by the currency" do
+      expect(Money.new(1.1111, 'USD').value).to eq(1.11)
+      expect(Money.new(1.1111, 'JPY').value).to eq(1)
+    end
+  end
+
   describe "with amount of $0" do
     before(:each) do
       @money = Money.new


### PR DESCRIPTION
# Why 
Currently we have `.round(2)` for any value irregardless of currency. Now that money has a notion of currency it makes more sense to round with the correct number of minor_units associated.

# What
Round any value provided to the money object
```
Money.new(1.295, 'USD') == Money.new(1.30)
```

# Side effects
3+ digit currencies will potentially be worth slightly more (1.11 -> 1.111)
```
 {"Bahraini Dinar BHD"=>1000},
 {"Iraqi Dinar IQD"=>1000},
 {"Jordanian Dinar JOD"=>1000},
 {"Kuwaiti Dinar KWD"=>1000},
 {"Libyan Dinar LYD"=>1000},
 {"Omani Rial OMR"=>1000},
 {"Tunisian Dinar TND"=>1000},
---
 {"Unidad de Fomento CLF"=>10000},
```

1 digit currencies will potentially be worth slightly less (1.01 -> 1)
```
 {"Burundian Franc BIF"=>1},
 {"Belarusian Ruble BYR"=>1},
 {"Chilean Peso CLP"=>1},
 {"Djiboutian Franc DJF"=>1},
 {"Guinean Franc GNF"=>1},
 {"Hungarian Forint HUF"=>1},
 {"Icelandic Króna ISK"=>1},
 {"Japanese Yen JPY"=>1},
 {"Comorian Franc KMF"=>1},
 {"South Korean Won KRW"=>1},
 {"Paraguayan Guaraní PYG"=>1},
 {"Rwandan Franc RWF"=>1},
 {"Ugandan Shilling UGX"=>1},
 {"Vietnamese Đồng VND"=>1},
 {"Vanuatu Vatu VUV"=>1},
---
 {"Malagasy Ariary MGA"=>5},
 {"Mauritanian Ouguiya MRO"=>5},
```