### PR TITLE
Improve test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ pkg
 # For rubinius:
 #*.rbc
 Gemfile.lock
+
+.rspec_status

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
   gem "simplecov", ">= 0"
   gem "rails"
   gem "sqlite3"
+  gem "pry-byebug"
 end
 
 gem 'codecov', :require => false, :group => :test

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AccountingMoneyParser do
+RSpec.describe AccountingMoneyParser do
   describe "parsing of amounts with period decimal separator" do
     before(:each) do
       @parser = AccountingMoneyParser.new

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-shared_examples_for "an object supporting to_money" do
+RSpec.shared_examples_for "an object supporting to_money" do
   it "supports to_money" do
     expect(@value.to_money).to eq(@money)
     expect(@value.to_money('CAD').currency).to eq(Money::Currency.find!('CAD'))
   end
 end
 
-describe Integer do
+RSpec.describe Integer do
   before(:each) do
     @value = 1
     @money = Money.new("1.00")
@@ -16,7 +16,7 @@ describe Integer do
   it_should_behave_like "an object supporting to_money"
 end
 
-describe Float do
+RSpec.describe Float do
   before(:each) do
     @value = 1.23
     @money = Money.new("1.23")
@@ -25,7 +25,7 @@ describe Float do
   it_should_behave_like "an object supporting to_money"
 end
 
-describe String do
+RSpec.describe String do
   before(:each) do
     @value = "1.23"
     @money = Money.new(@value)
@@ -34,7 +34,7 @@ describe String do
   it_should_behave_like "an object supporting to_money"
 end
 
-describe BigDecimal do
+RSpec.describe BigDecimal do
   before(:each) do
     @value = BigDecimal.new("1.23")
     @money = Money.new("1.23")

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Money::Currency::Loader do
+RSpec.describe Money::Currency::Loader do
 
   describe 'load_currencies' do
     it 'loads the iso currency file' do

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Currency" do
+RSpec.describe "Currency" do
   CURRENCY_DATA = {
     "iso_code": "USD",
     "name": "United States Dollar",

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Money::Helpers do
   describe 'subject.value_to_currency' do
     it 'returns itself if it is already a currency' do
       expect(subject.value_to_currency(Money::Currency.new('usd'))).to eq(Money::Currency.new('usd'))
+      expect(subject.value_to_currency(Money::NullCurrency.new)).to be_a(Money::NullCurrency)
     end
 
     it 'returns the default currency when value is nil' do
@@ -61,8 +62,8 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_currency('')).to eq(Money.default_currency)
     end
 
-    it 'returns the default currency when value is a null currency' do
-      expect(subject.value_to_currency(Money::NullCurrency.new)).to eq(Money.default_currency)
+    it 'returns the default currency when value is xxx' do
+      expect(subject.value_to_currency('xxx')).to eq(Money.default_currency)
     end
 
     it 'returns the matching currency' do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Money::Helpers do
+RSpec.describe Money::Helpers do
 
   describe 'value_to_decimal' do
     let (:amount) { BigDecimal.new('1.23') }

--- a/spec/money_accessor_spec.rb
+++ b/spec/money_accessor_spec.rb
@@ -16,7 +16,7 @@ class StructObject < Struct.new(:price)
   money_accessor :price
 end
 
-shared_examples_for "an object with a money accessor" do
+RSpec.shared_examples_for "an object with a money accessor" do
   it "generates an attribute reader that returns a money object" do
     object = described_class.new(100)
 
@@ -71,11 +71,11 @@ shared_examples_for "an object with a money accessor" do
   end
 end
 
-describe NormalObject do
+RSpec.describe NormalObject do
   it_behaves_like "an object with a money accessor"
 end
 
-describe StructObject do
+RSpec.describe StructObject do
   it_behaves_like "an object with a money accessor"
 
   it 'does not generate an ivar to store the price value' do

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -13,7 +13,7 @@ class CustomCurrencyMoneyRecord < ActiveRecord::Base
   money_column :price, currency_column: 'custom_currency'
 end
 
-describe "MoneyColumn" do
+RSpec.describe "MoneyColumn" do
 
   it "typecasts string to money" do
     m = MoneyRecord.new(:price => '1.01')

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MoneyParser do
+RSpec.describe MoneyParser do
   describe "parsing of amounts with period decimal separator" do
     before(:each) do
       @parser = MoneyParser.new

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -612,6 +612,29 @@ describe "Money" do
       expect(money).to eq(Money.new(750))
     end
 
+    it "accepts serialized NullCurrency objects" do
+      money = YAML.load(<<~EOS)
+        ---
+        !ruby/object:Money
+          currency: !ruby/object:Money::NullCurrency
+            symbol: >-
+              $
+            disambiguate_symbol:
+            iso_code: >-
+              XXX
+            iso_numeric: >-
+              999
+            name: >-
+              No Currency
+            smallest_denomination: 1
+            subunit_to_unit: 100
+            minor_units: 2
+          value: !ruby/object:BigDecimal 27:0.6935E2
+          cents: 6935
+      EOS
+      expect(money).to eq(Money.new(69.35))
+    end
+
     it "accepts BigDecimal values" do
       money = YAML.load(<<~EOS)
         ---

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'yaml'
 
-describe "Money" do
+RSpec.describe "Money" do
 
   before(:each) do
     @money = Money.new

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -527,9 +527,8 @@ RSpec.describe "Money" do
   end
 
   describe "parser dependency injection" do
-    before(:each) do
-      Money.parser = AccountingMoneyParser
-    end
+    before(:each) { Money.parser = AccountingMoneyParser }
+    after(:each) { Money.parser = MoneyParser }
 
     it "keeps AccountingMoneyParser class on new money objects" do
       expect(Money.new.class.parser).to eq(AccountingMoneyParser)
@@ -541,10 +540,6 @@ RSpec.describe "Money" do
 
     it "supports parenthesis from AccountingMoneyParser for .to_money" do
       expect("($5.00)".to_money).to eq(Money.new(-5))
-    end
-
-    after(:each) do
-      Money.parser = nil # reset
     end
   end
 
@@ -695,7 +690,7 @@ RSpec.describe "Money" do
 
     context "with .default_currency set" do
       before(:each) { Money.default_currency = Money::Currency.new('EUR') }
-      after(:each) { Money.default_currency = Money::NullCurrency }
+      after(:each) { Money.default_currency = Money::NullCurrency.new }
 
       it "can be nested and falls back to default_currency outside of the blocks" do
         money2, money3 = nil

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -24,7 +24,9 @@ describe "Money" do
   end
 
   it "defaults to 0 when constructed with an invalid string" do
-    expect(Money.new('invalid')).to eq(Money.new(0.00))
+    Money.active_support_deprecator.silence do
+      expect(Money.new('invalid')).to eq(Money.new(0.00))
+    end
   end
 
   it "to_s as a float with 2 decimal places" do
@@ -111,14 +113,14 @@ describe "Money" do
 
   it "keeps currency when doing a computation with a null currency" do
     currency = Money.new(10, 'JPY')
-    no_currency = Money.new(1)
+    no_currency = Money.new(1, Money::NullCurrency.new)
     expect((no_currency + currency).currency).to eq(Money::Currency.find!('JPY'))
     expect((currency - no_currency).currency).to eq(Money::Currency.find!('JPY'))
   end
 
   it "does not log a deprecation warning when adding with a null currency value" do
     currency = Money.new(10, 'USD')
-    no_currency = Money.new(1)
+    no_currency = Money.new(1, Money::NullCurrency.new)
     expect(Money).not_to receive(:deprecate)
     expect(no_currency + currency).to eq(Money.new(11, 'USD'))
     expect(currency - no_currency).to eq(Money.new(9, 'USD'))
@@ -134,11 +136,11 @@ describe "Money" do
   end
 
   it "inspects to a presentable string" do
-    expect(@money.inspect).to eq("#<Money value:0.00 currency:XXX>")
+    expect(@money.inspect).to eq("#<Money value:0.00 currency:CAD>")
   end
 
   it "is inspectable within an array" do
-    expect([@money].inspect).to eq("[#<Money value:0.00 currency:XXX>]")
+    expect([@money].inspect).to eq("[#<Money value:0.00 currency:CAD>]")
   end
 
   it "correctly support eql? as a value object" do
@@ -275,7 +277,7 @@ describe "Money" do
   end
 
   it "is creatable from an integer value in dollars and currency with no cents" do
-    expect(Money.from_subunits(1950, 'JPY')).to eq(Money.new(1950))
+    expect(Money.from_subunits(1950, 'JPY')).to eq(Money.new(1950, 'JPY'))
   end
 
   it "raises when constructed with a NaN value" do
@@ -632,7 +634,7 @@ describe "Money" do
           value: !ruby/object:BigDecimal 27:0.6935E2
           cents: 6935
       EOS
-      expect(money).to eq(Money.new(69.35))
+      expect(money).to eq(Money.new(69.35, Money::NullCurrency.new))
     end
 
     it "accepts BigDecimal values" do

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "NullCurrency" do
+RSpec.describe "NullCurrency" do
   let (:null_currency) {Money::NullCurrency.new}
 
   it 'exposes the same public interface as Currency' do

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,7 +1,0 @@
---colour
---format
-progress
---loadby
-mtime
---reverse
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,11 @@ load File.join(File.dirname(__FILE__), "schema.rb")
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
+  config.order = :random
+  
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
   config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,15 @@ load File.join(File.dirname(__FILE__), "schema.rb")
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
 
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
 end
 
 RSpec::Matchers.define :quack_like do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rspec'
+require 'pry-byebug'
+
 require 'rails'
 require 'active_record'
 require 'money'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ require 'rails'
 require 'active_record'
 require 'money'
 
+Money.active_support_deprecator.behavior = :raise
+Money.default_currency = Money::Currency.new('CAD')
+
 ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"
 
 load File.join(File.dirname(__FILE__), "schema.rb")


### PR DESCRIPTION
This PR combines a bunch of things to make the test suite hard, better, faster (or at least as fast) and stronger:
- Adds a test to ensure old serialized currency YAML in Shopify is correctly handled for future people refactoring this code.
- Use a real currency that can cause deprecation warnings and defaulting to raise on deprecation. The first part is more reflective of real app usage and the second one is to make sure it's loud and clear if we make a mistake.
- RSpec config to disable monkey patching, verifying method existance and arity when stubbing, and only using expect syntax for future proofing.
- Random test ordering to catch mistakes we make in the test suite with before and after hooks.
- Add Pry and byebug to debug anything, supersedes https://github.com/Shopify/money/pull/66
