### PR TITLE
NullCurrency to_s returns ''

### DIFF
--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -24,7 +24,10 @@ class Money
       self.class == other.class && iso_code == other.iso_code
     end
 
+    def to_s
+      ''
+    end
+    
     alias_method :==, :eql?
-    alias_method :to_s, :iso_code
   end
 end

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "NullCurrency" do
     end
   end
 
+  describe "#to_s" do
+    it 'is shown as an empty string' do
+      expect(null_currency.to_s).to eq('')
+    end
+  end
+
   describe "#compatible" do
     it "returns true for currency" do
       expect(null_currency.compatible?(Money::Currency.new('USD'))).to eq(true)


### PR DESCRIPTION
# What
`NullCurrency.new.to_s == ''` or `Money.new.currency.to_s == ''`

# Why
`to_s` is often used to show the currency to a user. It doesn't make sense to show the iso code in this case. This is similar to `nil.to_s == ''`