### PR TITLE
add support for subunits

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -83,6 +83,10 @@ class Money
     coder['currency'] = @currency.iso_code
   end
 
+  def subunits
+    (value * currency.subunit_to_unit).to_i
+  end
+
   def -@
     Money.new(-value, currency)
   end
@@ -189,11 +193,7 @@ class Money
     case style
     when :legacy_dollars, nil
       sprintf("%.2f", value)
-    when :legacy_cents
-      (value * 100).round.to_i.to_s
-    when :minor_units
-      (value * currency.subunit_to_unit).round.to_i.to_s
-    when :major_units
+    when :amount
       sprintf("%.#{currency.minor_units}f", value)
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -33,24 +33,14 @@ RSpec.describe "Money" do
     expect(@money.to_s).to eq("0.00")
   end
 
-  it "to_s with a legacy_cents style" do
-    expect(amount_money.to_s(:legacy_cents)).to eq("123")
-    expect(non_fractional_money.to_s(:legacy_cents)).to eq("100")
-  end
-
-  it "to_s with a minor_units style" do
-    expect(amount_money.to_s(:minor_units)).to eq("123")
-    expect(non_fractional_money.to_s(:minor_units)).to eq("1")
-  end
-
   it "to_s with a legacy_dollars style" do
     expect(amount_money.to_s(:legacy_dollars)).to eq("1.23")
     expect(non_fractional_money.to_s(:legacy_dollars)).to eq("1.00")
   end
 
-  it "to_s with a major_units style" do
-    expect(amount_money.to_s(:major_units)).to eq("1.23")
-    expect(non_fractional_money.to_s(:major_units)).to eq("1")
+  it "to_s with a amount style" do
+    expect(amount_money.to_s(:amount)).to eq("1.23")
+    expect(non_fractional_money.to_s(:amount)).to eq("1")
   end
 
   it "as_json as a float with 2 decimal places" do
@@ -340,6 +330,15 @@ RSpec.describe "Money" do
       expect(@money.hash).to eq(Money.new(1.00).hash)
     end
 
+  end
+
+  describe ".subunits" do
+    it 'multiplies by the number of decimal places for the currency' do
+      expect(Money.new(1, 'USD').subunits).to eq(100)
+      expect(Money.new(1, 'JPY').subunits).to eq(1)
+      expect(Money.new(1, 'IQD').subunits).to eq(1000)
+      expect(Money.new(1).subunits).to eq(100)
+    end
   end
 
   describe "with amount of $0" do


### PR DESCRIPTION
# Why
We want deprecate `cents` in favor of currency aware `subunits`. This PR adds the ability to use either. Needed for https://github.com/Shopify/money/issues/68

# What
- Add `Money.new(1, 'USD').subunits` 
- rename `to_s(:minor_units)` to `to_s(:subunits)` for consistency