### PR TITLE
Update `money_column` to use ActiveRecords `composed_of`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,40 @@ Money::Currency.new("JPY").minor_units  # => 0
 Money::Currency.new("MGA").minor_units  # => 1
 ```
 
+## Storing money
+
+Since money internally uses BigDecimal it's logical to use a `decimal` column
+(or `money` for PostgreSQL) for your database. The `money_column` method can
+generate methods for use with ActiveRecord:
+
+```ruby
+create_table :orders do |t|
+  t.decimal :sub_total, precision: 20, scale: 3
+  t.decimal :tax, precision: 20, scale: 3
+  t.string :currency, limit: 3
+end
+
+class Order < ApplicationRecord
+  money_column :sub_total, :tax
+end 
+``` 
+
+Because it called [`composed_of`](http://api.rubyonrails.org/classes/ActiveRecord/Aggregations/ClassMethods.html) 
+under the hood, you can use Money objects directly with the AR query interface :
+```ruby
+Order.create(sub_total: Money.new(3.50, 'USD'), tax: Money.new(0.35, 'USD'))
+Order.where(sub_total: Money.new(9.99, 'CAD'))
+``` 
+
+`money_column` uses an attribute called 'currency' by default. This can be
+overridden by supplying a symbol for the column name, e.g.:
+`currency: :other_column`. If your currency is hardcoded and there is no
+column, supply the currency code as a string instead. You can use multiple
+`money_column` calls to achieve the desired effects with currency on the model
+or attribute level.
+
+There are no validations generated. You can add these for the specified money
+and currency attributes as you normally would for any other.
 
 ## Contributing to money
 

--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ Order.where(sub_total: Money.new(9.99, 'CAD'))
 ``` 
 
 `money_column` uses an attribute called 'currency' by default. This can be
-overridden by supplying a symbol for the column name, e.g.:
-`currency: :other_column`. If your currency is hardcoded and there is no
-column, supply the currency code as a string instead. You can use multiple
-`money_column` calls to achieve the desired effects with currency on the model
-or attribute level.
+overridden by supplying another column name, e.g.: `currency_column: :other`.
+If your currency is hardcoded and there is no column, set a falsey currency
+column and supply the currency code instead:
+`money_column :price_usd, currency_column: false, currency: 'USD'`
+
+You can use multiple `money_column` calls to achieve the desired effects with
+currency on the model or attribute level.
 
 There are no validations generated. You can add these for the specified money
 and currency attributes as you normally would for any other.

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -7,4 +7,4 @@ require_relative 'money/deprecations'
 require_relative 'money/accounting_money_parser'
 require_relative 'money/core_extensions'
 require_relative 'money_accessor'
-require_relative 'money_column' if defined?(Rails)
+require_relative 'money_column' if defined?(ActiveRecord)

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -5,18 +5,19 @@ module MoneyColumn
     end
 
     module ClassMethods
-      def money_column(*columns, currency: :currency)
-        columns = columns.flatten
+      def money_column(*columns, currency_column: :currency, currency: false)
+        raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency_column && currency
 
-        if currency.is_a?(Symbol)
+        columns = columns.flatten
+        if currency_column
           columns.each do |column|
             composed_of(
               column.to_sym,
               class_name: 'Money',
-              mapping: [[column.to_s, 'value'], [currency.to_s, 'currency']]
+              mapping: [[column.to_s, 'value'], [currency_column.to_s, 'currency']]
             )
           end
-        else
+        elsif currency
           columns.each do |column|
             composed_of(
               column.to_sym,
@@ -25,6 +26,8 @@ module MoneyColumn
               constructor: proc { |value| Money.new(value, currency) }
             )
           end
+        else
+          raise ArgumentError, 'need to set either currency_column or currency'
         end
       end
     end

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -5,34 +5,25 @@ module MoneyColumn
     end
 
     module ClassMethods
-      def money_column(*columns, currency_column: 'currency')
-        Array(columns).flatten.each do |name|
-          define_method(name) do
-            value = read_attribute(name)
-            return nil if value.blank?
-            currency = read_attribute(currency_column)
-            Money.new(value, currency)
+      def money_column(*columns, currency: :currency)
+        columns = columns.flatten
+
+        if currency.is_a?(Symbol)
+          columns.each do |column|
+            composed_of(
+              column.to_sym,
+              class_name: 'Money',
+              mapping: [[column.to_s, 'value'], [currency.to_s, 'currency']]
+            )
           end
-
-          define_method("#{name}_before_type_cast") do
-            send(name) && sprintf("%.2f", send(name))
-          end
-
-          define_method("#{name}=") do |value|
-            if value.blank? || !value.respond_to?(:to_money)
-              write_attribute(name, nil)
-              nil
-            else
-              money = value.to_money
-              currency = Money::Helpers.value_to_currency(read_attribute(currency_column))
-
-              unless currency.compatible?(money.currency)
-                Money.deprecate("[money_column] currency mismatch between #{currency} and #{money.currency}.")
-              end
-
-              write_attribute(name, money.value)
-              money
-            end
+        else
+          columns.each do |column|
+            composed_of(
+              column.to_sym,
+              class_name: 'Money',
+              mapping: [column.to_s, 'value'],
+              constructor: proc { |value| Money.new(value, currency) }
+            )
           end
         end
       end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class MoneyRecord < ActiveRecord::Base
   RATE = 1.17
   before_validation do
-    self.price_usd = Money.new(self[:price] * RATE, 'USD') if attribute_present?('price')
+    self.price_usd = Money.new(self[:price] * RATE, 'USD')
   end
 
   money_column :price
@@ -25,7 +25,7 @@ RSpec.describe 'MoneyColumn' do
   let(:subject) { MoneyRecord.new(price: money, prix: toonie) }
   let(:record) do
     subject.save
-    subject.class.find(subject.id)
+    subject.reload
   end
 
   it 'returns money with currency from the default column' do

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -1,75 +1,84 @@
 require 'spec_helper'
 
 class MoneyRecord < ActiveRecord::Base
+  RATE = 1.17
+  before_validation do
+    self.price_usd = Money.new(self[:price] * RATE, 'USD') if attribute_present?('price')
+  end
+
   money_column :price
-  validates :price, numericality: true
+  money_column :prix, currency: :devise
+  money_column :price_usd, currency: 'USD'
 end
 
-class CurrencyMoneyRecord < ActiveRecord::Base
+class MoneyWithValidation < ActiveRecord::Base
+  self.table_name = 'money_records'
+  validates :price, :currency, presence: true
   money_column :price
 end
 
-class CustomCurrencyMoneyRecord < ActiveRecord::Base
-  money_column :price, currency_column: 'custom_currency'
-end
-
-RSpec.describe "MoneyColumn" do
-
-  it "typecasts string to money" do
-    m = MoneyRecord.new(:price => '1.01')
-    expect(m.price).to eq(Money.new(1.01))
+RSpec.describe 'MoneyColumn' do
+  let(:amount) { 1.23 }
+  let(:currency) { 'EUR' }
+  let(:money) { Money.new(amount, currency) }
+  let(:toonie) { Money.new(2.00, 'CAD') }
+  let(:subject) { MoneyRecord.new(price: money, prix: toonie) }
+  let(:record) do
+    subject.save
+    subject.class.find(subject.id)
   end
 
-  it "typecasts numeric to money" do
-    m = MoneyRecord.new(:price => 100)
-    expect(m.price).to eq(Money.new(100))
+  it 'returns money with currency from the default column' do
+    expect(record.price).to eq(Money.new(1.23, 'EUR'))
   end
 
-  it "typecasts blank to nil" do
-    m = MoneyRecord.new(:price => "")
-    expect(m.price).to eq(nil)
+  it 'returns money with currency from the specified column' do
+    expect(record.prix).to eq(Money.new(2.00, 'CAD'))
   end
 
-  it "typecasts money with missing currency column" do
-    m = MoneyRecord.new(price: Money.new(1.01, 'cad'))
-    expect(m.price).to eq(Money.new(1.01, Money::NullCurrency.new))
+  it 'returns money with the hardcoded currency' do
+    expect(record.price_usd).to eq(Money.new(1.44, 'USD'))
   end
 
-  it "typecasts money with currency" do
-    m = CurrencyMoneyRecord.new(price: 1.01, currency: 'cad')
-    expect(m.price).to eq(Money.new(1.01, 'CAD'))
+  describe 'non-fractional-currencies' do
+    let(:money) { Money.new(1, 'JPY') }
+
+    it 'returns money with currency from the default column' do
+      expect(record.price).to eq(Money.new(1, 'JPY'))
+    end
   end
 
-  it "typecasts money with a custom currency column" do
-    m = CustomCurrencyMoneyRecord.new(price: 1.01, custom_currency: 'cad')
-    expect(m.price).to eq(Money.new(1.01, 'CAD'))
+  describe 'three-decimal currencies' do
+    let(:money) { Money.new(1.234, 'JOD') }
+
+    it 'returns money with currency from the default column' do
+      expect(record.price).to eq(Money.new(1.234, 'JOD'))
+    end
   end
 
-  it "typecasts invalid string to empty money" do
-    m = MoneyRecord.new(:price => "magic")
-    expect(m.price).to eq(Money.new(0))
+  describe 'garbage amount' do
+    let(:amount) { 'foo' }
+
+    it 'raises a deprecation warning' do
+      expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+    end
   end
 
-  it "typecasts value that does not respond to to_money as nil" do
-    m = MoneyRecord.new(:price => true)
-    expect(m.price).to eq(nil)
+  describe 'garbage currency' do
+    let(:currency) { 'foo' }
+
+    it 'raises an UnknownCurrency error' do
+      expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+    end
   end
 
-  it "validates properly" do
-    m = MoneyRecord.new(:price => '1.00')
-    expect(m.valid?).to eq(true)
-  end
+  describe 'null currency and validations' do
+    let(:currency) { Money::NullCurrency.new }
+    let(:subject) { MoneyWithValidation.new(price: money) }
 
-  it "does not save the currency but shows a deprecation warning" do
-    m = CustomCurrencyMoneyRecord.new(price: 1.01, custom_currency: 'cad')
-    expect(Money).to receive(:deprecate).once
-    m.price = Money.new(10, 'USD')
-    expect(m.price).to eq(Money.new(10, 'CAD'))
-  end
-
-  it "does not raise when an invalid currency is stored in the db" do
-    m = CurrencyMoneyRecord.new(price: 1.01, currency: 'invalid')
-    expect(Money).to receive(:deprecate).once
-    m.price = Money.new(10, 'USD')
+    it 'is not allowed to be saved because `to_s` returns a blank string' do
+      subject.valid?
+      expect(subject.errors[:currency]).to include("can't be blank")
+    end
   end
 end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -7,8 +7,8 @@ class MoneyRecord < ActiveRecord::Base
   end
 
   money_column :price
-  money_column :prix, currency: :devise
-  money_column :price_usd, currency: 'USD'
+  money_column :prix, currency_column: :devise
+  money_column :price_usd, currency_column: false, currency: 'USD'
 end
 
 class MoneyWithValidation < ActiveRecord::Base
@@ -69,6 +69,32 @@ RSpec.describe 'MoneyColumn' do
 
     it 'raises an UnknownCurrency error' do
       expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+    end
+  end
+
+  describe 'wrong money_column currency arguments' do
+    let(:subject) do
+      class MoneyWithWrongCurrencyArguments < ActiveRecord::Base
+        self.table_name = 'money_records'
+        money_column :price, currency_column: :currency, currency: 'USD'
+      end
+    end
+
+    it 'raises an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError, 'cannot set both currency_column and a fixed currency')
+    end
+  end
+
+  describe 'missing money_column currency arguments' do
+    let(:subject) do
+      class MoneyWithMissingCurrencyArguments < ActiveRecord::Base
+        self.table_name = 'money_records'
+        money_column :price, currency_column: false, currency: false
+      end
+    end
+
+    it 'raises an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError, 'need to set either currency_column or currency')
     end
   end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,21 +1,9 @@
 ActiveRecord::Schema.define do
   create_table "money_records", :force => true do |t|
-    t.decimal  "price"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "currency_money_records", :force => true do |t|
-    t.decimal  "price"
-    t.string   "currency"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "custom_currency_money_records", :force => true do |t|
-    t.decimal  "price"
-    t.string   "custom_currency"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.decimal  "price", precision: 20, scale: 3, default: '0.000'
+    t.string   "currency", limit: 3
+    t.decimal  "prix", precision: 20, scale: 3, default: '0.000'
+    t.string   "devise", limit: 3
+    t.decimal  "price_usd"
   end
 end


### PR DESCRIPTION
Supersedes #82 - while the advice still stands to use `composed_of` for performance reasons, typing those out can get very tedious and `money_column` can help with that for the use cases we've seen in Shopify: multiple columns with the same currency and/or a column that is in a static currency.

I've experimented with adding default presence validations but it felt too prescriptive. Since it "just works" I've documented just that in both the readme and tests.