### PR TITLE
Deprecate cents in favour of subunits

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -69,7 +69,7 @@ class Money
   def initialize(value = 0, currency = nil)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
     @currency = Helpers.value_to_currency(currency)
-    @value = Helpers.value_to_decimal(value).round(2)
+    @value = Helpers.value_to_decimal(value).round(@currency.minor_units)
     @subunits = (@value * @currency.subunit_to_unit).to_i
     freeze
   end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,7 +1,7 @@
 class Money
   include Comparable
 
-  attr_reader :value, :cents, :currency
+  attr_reader :value, :subunits, :currency
 
   class << self
     attr_accessor :parser, :default_currency
@@ -70,7 +70,7 @@ class Money
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
     @currency = Helpers.value_to_currency(currency)
     @value = Helpers.value_to_decimal(value).round(2)
-    @cents = (@value * 100).to_i
+    @subunits = (@value * @currency.subunit_to_unit).to_i
     freeze
   end
 
@@ -83,8 +83,10 @@ class Money
     coder['currency'] = @currency.iso_code
   end
 
-  def subunits
-    (value * currency.subunit_to_unit).to_i
+  def cents
+    Money.deprecate('`money.cents` is deprecated and will be removed in the next major release.
+      Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
+    (value * 100).to_i
   end
 
   def -@

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -343,6 +343,13 @@ RSpec.describe "Money" do
     end
   end
 
+  describe "value" do
+    it "rounds to the number of minor units provided by the currency" do
+      expect(Money.new(1.1111, 'USD').value).to eq(1.11)
+      expect(Money.new(1.1111, 'JPY').value).to eq(1)
+    end
+  end
+
   describe "with amount of $0" do
     before(:each) do
       @money = Money.new

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -227,7 +227,9 @@ RSpec.describe "Money" do
   end
 
   it "returns cents in to_liquid" do
-    expect(Money.new(1.00).to_liquid).to eq(100)
+    Money.active_support_deprecator.silence do
+      expect(Money.new(1.00).to_liquid).to eq(100)
+    end
   end
 
   it "returns cents in to_json" do
@@ -332,7 +334,7 @@ RSpec.describe "Money" do
 
   end
 
-  describe ".subunits" do
+  describe "#subunits" do
     it 'multiplies by the number of decimal places for the currency' do
       expect(Money.new(1, 'USD').subunits).to eq(100)
       expect(Money.new(1, 'JPY').subunits).to eq(1)
@@ -381,11 +383,17 @@ RSpec.describe "Money" do
     end
 
     it "returns cents as 100 cents" do
-      expect(@money.cents).to eq(100)
+      Money.active_support_deprecator.silence do
+        expect(@money.cents).to eq(100)
+      end
+    end
+
+    it "returns cents as 100 cents" do
+      expect(@money.subunits).to eq(100)
     end
 
     it "returns cents as a Fixnum" do
-      expect(@money.cents).to be_an_instance_of(Fixnum)
+      expect(@money.subunits).to be_an_instance_of(Fixnum)
     end
 
     it "is greater than $0" do
@@ -412,11 +420,17 @@ RSpec.describe "Money" do
       expect(moneys[1]).to eq(Money.new(0.03))
     end
 
+    specify "#allocate does not lose dollars with non-decimal currency" do
+      moneys = Money.new(5, 'JPY').allocate([0.3,0.7])
+      expect(moneys[0]).to eq(Money.new(2, 'JPY'))
+      expect(moneys[1]).to eq(Money.new(3, 'JPY'))
+    end
+
     specify "#allocate does not lose pennies even when given a lossy split" do
       moneys = Money.new(1).allocate([0.333,0.333, 0.333])
-      expect(moneys[0].cents).to eq(34)
-      expect(moneys[1].cents).to eq(33)
-      expect(moneys[2].cents).to eq(33)
+      expect(moneys[0].subunits).to eq(34)
+      expect(moneys[1].subunits).to eq(33)
+      expect(moneys[2].subunits).to eq(33)
     end
 
     specify "#allocate requires total to be less than 1" do
@@ -444,6 +458,12 @@ RSpec.describe "Money" do
       expect(
         Money.new(30.75).allocate_max_amounts([Money.new(26), Money.new(4.75)]),
       ).to eq([Money.new(26), Money.new(4.75)])
+    end
+
+    specify "#allocate_max_amounts returns the weighted allocation without exceeding the maxima when there is room for the remainder with currency" do
+      expect(
+        Money.new(3075, 'JPY').allocate_max_amounts([Money.new(2600, 'JPY'), Money.new(475, 'JPY')]),
+      ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
     end
 
     specify "#allocate_max_amounts drops the remainder when returning the weighted allocation without exceeding the maxima when there is no room for the remainder" do
@@ -495,11 +515,22 @@ RSpec.describe "Money" do
       expect(Money.new(0.05).split(2)).to eq([Money.new(0.03), Money.new(0.02)])
     end
 
+    specify "#split does not lose dollars with non-decimal currencies" do
+      expect(Money.new(5, 'JPY').split(2)).to eq([Money.new(3, 'JPY'), Money.new(2, 'JPY')])
+    end
+
     specify "#split a dollar" do
       moneys = Money.new(1).split(3)
-      expect(moneys[0].cents).to eq(34)
-      expect(moneys[1].cents).to eq(33)
-      expect(moneys[2].cents).to eq(33)
+      expect(moneys[0].subunits).to eq(34)
+      expect(moneys[1].subunits).to eq(33)
+      expect(moneys[2].subunits).to eq(33)
+    end
+
+    specify "#split a 100 yen" do
+      moneys = Money.new(100, 'JPY').split(3)
+      expect(moneys[0].value).to eq(34)
+      expect(moneys[1].value).to eq(33)
+      expect(moneys[2].value).to eq(33)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -347,6 +347,7 @@ RSpec.describe "Money" do
     it "rounds to the number of minor units provided by the currency" do
       expect(Money.new(1.1111, 'USD').value).to eq(1.11)
       expect(Money.new(1.1111, 'JPY').value).to eq(1)
+      expect(Money.new(1.1111, 'IQD').value).to eq(1.111)
     end
   end
 
@@ -431,6 +432,12 @@ RSpec.describe "Money" do
       moneys = Money.new(5, 'JPY').allocate([0.3,0.7])
       expect(moneys[0]).to eq(Money.new(2, 'JPY'))
       expect(moneys[1]).to eq(Money.new(3, 'JPY'))
+    end
+
+    specify "#allocate does not lose dollars with three decimal currency" do
+      moneys = Money.new(0.005, 'JOD').allocate([0.3,0.7])
+      expect(moneys[0]).to eq(Money.new(0.002, 'JOD'))
+      expect(moneys[1]).to eq(Money.new(0.003, 'JOD'))
     end
 
     specify "#allocate does not lose pennies even when given a lossy split" do


### PR DESCRIPTION
# Why
cents are not currency aware, which is especially important for currencies that have no minor units like the japanese yen.

re https://github.com/Shopify/shopify/issues/121143

# What
- deprecate `money.cents`
- modify allocation so it allocates subunits correctly
- added tests to verify specifically JPY