### PR TITLE
Allow non-standard currencies to be normalized into known ones

### DIFF
--- a/config/currency_normalization_map.json
+++ b/config/currency_normalization_map.json
@@ -1,0 +1,20 @@
+{
+  "ARN": "ARS",
+  "AZM": "AZN",
+  "CHP": "CLP",
+  "DHS": "AED",
+  "ECD": "XCD",
+  "JAD": "JMD",
+  "JYE": "JPY",
+  "KUD": "KWD",
+  "MZM": "MZN",
+  "NMP": "MXN",
+  "NTD": "TWD",
+  "RDD": "DOP",
+  "RM": "MYR",
+  "RMB": "CNY",
+  "SFR": "CHF",
+  "SID": "SGD",
+  "UKL": "GBP",
+  "WON": "KRW"
+}

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -4,13 +4,14 @@ class Money
   class Currency
     @@mutex = Mutex.new
     @@loaded_currencies = {}
+    @@currency_normalization_map = nil
 
     class UnknownCurrency < ArgumentError; end
 
     class << self
       def new(currency_iso)
         raise UnknownCurrency, "Currency can't be blank" if currency_iso.nil? || currency_iso.empty?
-        iso = currency_iso.to_s.downcase
+        iso = normalize_currency(currency_iso)
         @@loaded_currencies[iso] || @@mutex.synchronize { @@loaded_currencies[iso] = super(iso) }
       end
       alias_method :find!, :new
@@ -24,6 +25,20 @@ class Money
       def currencies
         @@currencies ||= Loader.load_currencies
       end
+
+      def normalize_currency(currency_code)
+        code = currency_code.to_s.downcase
+        return code if currencies.keys.include?(code)
+
+        code = currency_normalization_map[code.upcase]
+        return code.downcase if code
+
+        raise(UnknownCurrency, "Currency #{code} is not a known currency, nor can it be converted to one.")
+      end
+
+      def currency_normalization_map
+        @@currency_normalization_map ||= Loader.load_currency_normalization_map
+      end
     end
 
     attr_reader :iso_code, :iso_numeric, :name, :smallest_denomination,
@@ -31,7 +46,7 @@ class Money
 
     def initialize(currency_iso)
       data = self.class.currencies[currency_iso]
-      raise UnknownCurrency, "Invalid iso4217 currency '#{currency_iso}'" unless data
+      raise UnknownCurrency, "Invalid currency '#{currency_iso}'" unless data
       @symbol                = data['symbol']
       @disambiguate_symbol   = data['disambiguate_symbol'] || data['symbol']
       @iso_code              = data['iso_code']

--- a/lib/money/currency/loader.rb
+++ b/lib/money/currency/loader.rb
@@ -12,6 +12,10 @@ class Money
         currencies.merge! parse_currency_file("currency_iso.json")
       end
 
+      def load_currency_normalization_map
+        parse_currency_file("currency_normalization_map.json")
+      end
+
       private
 
       def parse_currency_file(filename)

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -18,4 +18,26 @@ RSpec.describe Money::Currency::Loader do
       expect(subject.load_currencies['eek']['iso_code']).to eq('EEK')
     end
   end
+
+  describe 'load_currency_normalization_map' do
+    let(:mapping_inputs) { subject.load_currency_normalization_map.keys }
+    let(:mapping_outputs) { subject.load_currency_normalization_map.values }
+    let(:known_currencies) { subject.load_currencies.keys.map(&:upcase) }
+
+    it 'loads the normalization mapping file' do
+      expect(subject.load_currency_normalization_map['NTD']).to eq('TWD')
+    end
+
+    it 'maps to known codes in the currency files' do
+      expect(known_currencies).to include(*mapping_outputs)
+    end
+
+    it 'does not map already known codes in the currency files' do
+      expect(known_currencies).to_not include(*mapping_inputs)
+    end
+
+    it 'does not map to another code that needs mapping' do
+      expect(mapping_inputs).to_not include(*mapping_outputs)
+    end
+  end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe "Currency" do
       expect(Money::Currency.new('usd').iso_code).to eq('USD')
     end
 
-    it "raises when the currency is invalid" do
+    it "normalizes known non-standard codes to standard codes" do
+      expect(Money::Currency.new('UKL').iso_code).to eq('GBP')
+    end
+
+    it "raises when the currency is invalid and cannot be mapped to a valid one" do
       expect { Money::Currency.new('yyy') }.to raise_error(Money::Currency::UnknownCurrency)
     end
 


### PR DESCRIPTION
The list is lifted from https://github.com/Shopify/active_utils/blob/master/lib/active_utils/currency_code.rb except for PES - according to https://www.currency-iso.org/dam/downloads/lists/list_three.xml it was withdrawn on 1986 so it's unlikely we'll see those in transactions. 

We should definitely look into upgrading our currency database because like #85 it turns out to be incomplete.