### PR TITLE
support for currency_read_only money_column helper

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -5,29 +5,37 @@ module MoneyColumn
     end
 
     module ClassMethods
-      def money_column(*columns, currency_column: :currency, currency: false)
-        raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency_column && currency
+      def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false)
+        raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency && currency_column
 
-        columns = columns.flatten
-        if currency_column
-          columns.each do |column|
+        if currency
+          currency = Money::Currency.find!(currency).to_s
+        else
+          currency_column ||= 'currency'
+        end
+
+        columns.flatten.each do |column|
+          if currency_read_only || currency
+            define_method column do
+              return instance_variable_get("@#{column}") if instance_variable_defined?("@#{column}")
+              instance_variable_set("@#{column}", Money.new(read_attribute(column), currency || read_attribute(currency_column)))
+            end
+
+            define_method "#{column}=" do |money|
+              currency_db = currency || read_attribute(currency_column)
+              if currency_db != money.currency.to_s
+                Money.deprecate("[money_column] currency mismatch between #{currency_db} and #{money.currency}.")
+              end
+              write_attribute(column, money.value)
+              instance_variable_set("@#{column}",  Money.new(money.value, currency_db))
+            end
+          else
             composed_of(
               column.to_sym,
               class_name: 'Money',
               mapping: [[column.to_s, 'value'], [currency_column.to_s, 'currency']]
             )
           end
-        elsif currency
-          columns.each do |column|
-            composed_of(
-              column.to_sym,
-              class_name: 'Money',
-              mapping: [column.to_s, 'value'],
-              constructor: proc { |value| Money.new(value, currency) }
-            )
-          end
-        else
-          raise ArgumentError, 'need to set either currency_column or currency'
         end
       end
     end


### PR DESCRIPTION
# Why
Support for only reading the currency from the DB but not writing it. This helps with the transition period to currency. 
https://github.com/Shopify/shopify/issues/121143

```ruby
money_column :price, currency_column: 'my_currency', currency_read_only: true
```

# What
- add the `currency_read_only` option
- Show a deprecation warning the money currency doesn't match what is being saved to the DB
- read creates a money object with the currency from the DB