### PR TITLE
Add Money#clamp which ensures the value is within boundries

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -329,6 +329,25 @@ class Money
     return result
   end
 
+  # Clamps the value to be within the specified minimum and maximum. Returns
+  # self if the value is within bounds, otherwise a new Money object with the
+  # closest min or max value.
+  #
+  # @example
+  #   Money.new(50, "CAD").clamp(1, 100) #=> Money.new(10, "CAD")
+  #
+  #   Money.new(120, "CAD").clamp(0, 100) #=> Money.new(100, "CAD")
+  def clamp(min, max)
+    raise ArgumentError, 'min cannot be greater than max' if min > max
+
+    clamped_value = [min, self.value, max].sort[1]
+    if self.value == clamped_value
+      self
+    else
+      Money.new(clamped_value, self.currency)
+    end
+  end
+
   private
 
   def all_rational?(splits)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -755,4 +755,27 @@ RSpec.describe "Money" do
       end
     end
   end
+
+  describe '.clamp' do
+    let(:max) { 9000 }
+    let(:min) { -max }
+
+    it 'returns the same value if the value is within the min..max range' do
+      money = Money.new(5000, 'EUR').clamp(min, max)
+      expect(money.value).to eq(5000)
+      expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'returns the max value if the original value is larger' do
+      money = Money.new(9001, 'EUR').clamp(min, max)
+      expect(money.clamp(min, max).value).to eq(9000)
+      expect(money.clamp(min, max).currency.iso_code).to eq('EUR')
+    end
+
+    it 'returns the min value if the original value is smaller' do
+      money = Money.new(-9001, 'EUR').clamp(min, max)
+      expect(money.value).to eq(-9000)
+      expect(money.currency.iso_code).to eq('EUR')
+    end
+  end
 end


### PR DESCRIPTION
Similar to Ruby 2.4's [clamp method](https://ruby-doc.org/core-2.4.0/Comparable.html#method-i-clamp). For example useful to ensure no [surprising overflow handling](https://stackoverflow.com/questions/14216642/warning1264out-of-range-error-in-mysql) when dealing with very large values from user input.