### PR TITLE
Comment out deprecation message

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -84,8 +84,7 @@ class Money
   end
 
   def cents
-    Money.deprecate('`money.cents` is deprecated and will be removed in the next major release.
-      Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
+    # Money.deprecate('`money.cents` is deprecated and will be removed in the next major release. Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
     (value * 100).to_i
   end
 


### PR DESCRIPTION
Because: https://github.com/Shopify/shopify/pull/124970#issuecomment-322099194

The people who know how to deal with this properly are on holidays and/or too busy. So, doing the dumb thing for now and just commenting it out until it can be fixed properly.

