### PR TITLE
support for saving nil into a money_column

### DIFF
--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -117,4 +117,12 @@ RSpec.describe 'MoneyColumn' do
       expect(record.price.currency.to_s).to eq('USD')
     end
   end
+
+  describe 'saving null' do
+    it 'returns nil when money value have not been set' do
+      record = MoneyRecord.new(price: nil, price_usd: nil)
+      expect(record.price).to eq(nil)
+      expect(record.price_usd).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
# Why
Fix `NoMethodError: undefined method 'currency' for nil:NilClass`. 
We need a way to save nil values as a way to reset the default "no value" state. Similarly we need to be able to read nil values without converting them to a zero money object.

# What
- `composed_of` with option allow_nil set to true
-  when ignoring currency on save, set nil when value passed in is nil