### PR TITLE
refactor money column

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -28,11 +28,11 @@ module MoneyColumn
     module ClassMethods
       def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false)
         raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency && currency_column
+        raise ArgumentError, 'must set one of :currency_column or :currency options' unless currency || currency_column
 
         if currency
           currency_object = Money::Currency.find!(currency).to_s
         else
-          currency_column ||= 'currency'
           define_method "#{currency_column}=" do |value|
             @money_column_cache.clear
             super(value)

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -4,46 +4,82 @@ module MoneyColumn
       base.extend(ClassMethods)
     end
 
+    def reload(*)
+      clear_money_column_cache
+      super
+    end
+
+    def initialize_dup(*)
+      @money_column_cache = {}
+      super
+    end
+
+    private
+
+    def clear_money_column_cache
+      @money_column_cache.clear if persisted?
+    end
+
+    def init_internals
+      @money_column_cache = {}
+      super
+    end
+
     module ClassMethods
       def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false)
         raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency && currency_column
 
         if currency
-          currency = Money::Currency.find!(currency).to_s
+          currency_object = Money::Currency.find!(currency).to_s
         else
           currency_column ||= 'currency'
+          define_method "#{currency_column}=" do |value|
+            @money_column_cache.clear
+            super(value)
+          end
         end
 
         columns.flatten.each do |column|
           if currency_read_only || currency
-            define_method column do
-              return instance_variable_get("@#{column}") if instance_variable_defined?("@#{column}")
-              value = read_attribute(column)
-              iso = currency || read_attribute(currency_column)
-              instance_variable_set("@#{column}", value ? Money.new(value, iso) : nil)
-            end
-
-            define_method "#{column}=" do |money|
-              if money.nil?
-                write_attribute(column, nil)
-                return instance_variable_set("@#{column}",  nil)
-              end
-
-              currency_db = currency || read_attribute(currency_column)
-              if currency_db != money.currency.to_s
-                Money.deprecate("[money_column] currency mismatch between #{currency_db} and #{money.currency}.")
-              end
-              write_attribute(column, money.value)
-              instance_variable_set("@#{column}",  Money.new(money.value, currency_db))
-            end
+            money_column_reader(column, currency_column, currency_object)
+            money_column_writer(column, currency_column, currency_object)
           else
             composed_of(
               column.to_sym,
               class_name: 'Money',
               mapping: [[column.to_s, 'value'], [currency_column.to_s, 'currency']],
-              allow_nil: true
+              converter: Proc.new { |value| value.to_money },
+              allow_nil: true,
             )
           end
+        end
+      end
+
+      private
+
+      def money_column_reader(column, currency_column, currency_object)
+        define_method column do
+          return @money_column_cache[column] if @money_column_cache[column]
+          return unless value = read_attribute(column)
+          iso = currency_object || try(currency_column)
+          @money_column_cache[column] = Money.new(value, iso)
+        end
+      end
+
+      def money_column_writer(column, currency_column, currency_object)
+        define_method "#{column}=" do |money|
+          if money.blank?
+            write_attribute(column, nil)
+            return @money_column_cache[column] = nil
+          end
+          money = money.to_money
+          currency_db = Money::Helpers.value_to_currency(currency_object || try(currency_column))
+
+          unless currency_db && currency_db.compatible?(money.currency)
+            Money.deprecate("[money_column] currency mismatch between #{currency_db} and #{money.currency}.")
+          end
+          write_attribute(column, money.value)
+          @money_column_cache[column] = Money.new(money.value, currency_db)
         end
       end
     end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -5,7 +5,7 @@ class MoneyRecord < ActiveRecord::Base
   before_validation do
     self.price_usd = Money.new(self[:price] * RATE, 'USD')
   end
-  money_column :price
+  money_column :price, currency_column: 'currency'
   money_column :prix, currency_column: :devise
   money_column :price_usd, currency: 'USD'
 end
@@ -13,12 +13,12 @@ end
 class MoneyWithValidation < ActiveRecord::Base
   self.table_name = 'money_records'
   validates :price, :currency, presence: true
-  money_column :price
+  money_column :price, currency_column: 'currency'
 end
 
 class MoneyWithReadOnlyCurrency < ActiveRecord::Base
   self.table_name = 'money_records'
-  money_column :price, currency_read_only: true
+  money_column :price, currency_column: 'currency', currency_read_only: true
 end
 
 RSpec.describe 'MoneyColumn' do


### PR DESCRIPTION
# Why
https://github.com/Shopify/shopify/issues/121143

Money column was missing some key features namely
- proper reload fixes #91
- legacy support for saving `1.23` strings and 1.23 floats in addition to money objects
- proper handling of invalid currencies from the DB
- changing the currency invalidates the money column cache
- make the currency column explicit (remove default name)

# What
Tests and moved the code in functions for better readability