### PR TITLE
active record queries with money columns

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -51,7 +51,7 @@ class Money
     end
 
     def no_currency?(currency)
-      currency.nil? || currency.empty? || currency.to_s.downcase == 'xxx'
+      currency.nil? || currency.to_s.empty? || currency.to_s.downcase == 'xxx'
     end
   end
 end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,7 +1,7 @@
 class Money
   include Comparable
 
-  attr_reader :value, :subunits, :currency
+  attr_reader :value, :subunits, :currency, :currency_iso
 
   class << self
     attr_accessor :parser, :default_currency
@@ -69,6 +69,7 @@ class Money
   def initialize(value = 0, currency = nil)
     raise ArgumentError if value.respond_to?(:nan?) && value.nan?
     @currency = Helpers.value_to_currency(currency)
+    @currency_iso = @currency.to_s
     @value = Helpers.value_to_decimal(value).round(@currency.minor_units)
     @subunits = (@value * @currency.subunit_to_unit).to_i
     freeze
@@ -80,7 +81,7 @@ class Money
 
   def encode_with(coder)
     coder['value'] = @value.to_s('F')
-    coder['currency'] = @currency.iso_code
+    coder['currency'] = @currency_iso
   end
 
   def cents

--- a/lib/money_column.rb
+++ b/lib/money_column.rb
@@ -1,2 +1,3 @@
 require_relative 'money_column/active_record_hooks'
 require_relative 'money_column/railtie'
+require_relative 'money_column/type'

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -79,10 +79,14 @@ module MoneyColumn
             write_attribute(column, nil)
             return @money_column_cache[column] = nil
           end
-          money = money.to_money
 
           currency_db = currency_iso || try(currency_column)
           currency_object = Money::Helpers.value_to_currency(currency_db)
+
+          unless money.is_a?(Money)
+            write_attribute(column, money)
+            return @money_column_cache[column] = Money.new(money, currency_object)
+          end
 
           if currency_db && !currency_object.compatible?(money.currency)
             Money.deprecate("[money_column] currency mismatch between #{currency_object} and #{money.currency}.")

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -66,20 +66,22 @@ module MoneyColumn
         end
       end
 
-      def money_column_writer(column, currency_column, currency_object)
+      def money_column_writer(column, currency_column, currency_iso)
         define_method "#{column}=" do |money|
           if money.blank?
             write_attribute(column, nil)
             return @money_column_cache[column] = nil
           end
           money = money.to_money
-          currency_db = Money::Helpers.value_to_currency(currency_object || try(currency_column))
 
-          unless currency_db && currency_db.compatible?(money.currency)
-            Money.deprecate("[money_column] currency mismatch between #{currency_db} and #{money.currency}.")
+          currency_db = currency_iso || try(currency_column)
+          currency_object = Money::Helpers.value_to_currency(currency_db)
+
+          if currency_db && !currency_object.compatible?(money.currency)
+            Money.deprecate("[money_column] currency mismatch between #{currency_object} and #{money.currency}.")
           end
           write_attribute(column, money.value)
-          @money_column_cache[column] = Money.new(money.value, currency_db)
+          @money_column_cache[column] = Money.new(money.value, currency_object)
         end
       end
     end

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -28,15 +28,13 @@ module MoneyColumn
     module ClassMethods
       def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false)
         raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency && currency_column
-        raise ArgumentError, 'must set one of :currency_column or :currency options' unless currency || currency_column
 
         if currency
           currency_object = Money::Currency.find!(currency).to_s
+        elsif currency_column
+          clear_cache_on_currency_change(currency_column)
         else
-          define_method "#{currency_column}=" do |value|
-            @money_column_cache.clear
-            super(value)
-          end
+          raise ArgumentError, 'must set one of :currency_column or :currency options'
         end
 
         columns.flatten.each do |column|
@@ -56,6 +54,14 @@ module MoneyColumn
       end
 
       private
+
+      def clear_cache_on_currency_change(currency_column)
+        return unless currency_column
+        define_method "#{currency_column}=" do |value|
+          @money_column_cache.clear
+          super(value)
+        end
+      end
 
       def money_column_reader(column, currency_column, currency_object)
         define_method column do

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -39,6 +39,7 @@ module MoneyColumn
 
         columns.flatten.each do |column|
           if currency_read_only || currency
+            attribute(column, MoneyColumn::Type.new)
             money_column_reader(column, currency_column, currency_object)
             money_column_writer(column, currency_column, currency_object)
           else

--- a/lib/money_column/type.rb
+++ b/lib/money_column/type.rb
@@ -1,0 +1,12 @@
+module MoneyColumn
+  class Type < ActiveRecord::Type::Decimal
+    def serialize(money)
+      case money
+      when ::Money
+        super(money.value)
+      else
+        super(money.blank? ? nil : money)
+      end
+    end
+  end
+end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -189,13 +189,14 @@ RSpec.describe 'MoneyColumn' do
 
   describe 'active record queries' do
     it 'searches for both value and currency when currency_read_only is false' do
-      skip
+      record
       MoneyRecord.create(price: Money.new(amount, 'USD'))
-      expect(MoneyRecord.find_by(price: money)).to eq(record)
+      expect(MoneyRecord.find_by(price: money, currency: money.currency_iso)).to eq(record)
+      expect(MoneyRecord.find_by(price: 1.23)).to eq(record)
+      expect(MoneyRecord.where("price >= ?", money.value).first).to eq(record)
     end
 
     it 'searches for only value when currency_read_only is true' do
-      MoneyWithReadOnlyCurrency.delete_all
       record = MoneyWithReadOnlyCurrency.create(price: Money.new(1, 'JPY'), currency: 'JPY')
       expect(MoneyWithReadOnlyCurrency.where(price: Money.new(1, 'JPY')).first).to eq(record)
       expect(MoneyWithReadOnlyCurrency.where(price: Money.new(1)).first).to eq(record)

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -167,4 +167,18 @@ RSpec.describe 'MoneyColumn' do
       expect(record.price_usd).to eq(nil)
     end
   end
+
+  describe 'active record queries' do
+    it 'searches for both value and currency when currency_read_only is false' do
+      MoneyRecord.create(price: Money.new(amount, 'USD'))
+      expect(MoneyRecord.find_by(price: money)).to eq(record)
+    end
+
+    it 'searches for only value when currency_read_only is true' do
+      MoneyWithReadOnlyCurrency.delete_all
+      record = MoneyWithReadOnlyCurrency.create(price: Money.new(1, 'JPY'), currency: 'JPY')
+      expect(MoneyWithReadOnlyCurrency.where(price: Money.new(1, 'JPY')).first).to eq(record)
+      expect(MoneyWithReadOnlyCurrency.where(price: Money.new(1)).first).to eq(record)
+    end
+  end
 end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe 'MoneyColumn' do
     end
   end
 
+  describe 'missing money_column currency arguments' do
+    let(:subject) do
+      class MoneyWithWrongCurrencyArguments < ActiveRecord::Base
+        self.table_name = 'money_records'
+        money_column :price
+      end
+    end
+
+    it 'raises an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError, 'must set one of :currency_column or :currency options')
+    end
+  end
+
   describe 'null currency and validations' do
     let(:currency) { Money::NullCurrency.new }
     let(:subject) { MoneyWithValidation.new(price: money) }

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -60,15 +60,21 @@ RSpec.describe 'MoneyColumn' do
   it 'handles legacy support for saving floats' do
     record.update(price: 3.21, prix: 3.21)
     expect(record.price.value).to eq(3.21)
+    expect(record.price.currency_iso).to eq(currency)
     expect(record.price_usd.value).to eq(3.76)
+    expect(record.price_usd.currency_iso).to eq('USD')
     expect(record.prix.value).to eq(3.21)
+    expect(record.prix.currency_iso).to eq('CAD')
   end
 
   it 'handles legacy support for saving string' do
     record.update(price: '3.21', prix: '3.21')
     expect(record.price.value).to eq(3.21)
+    expect(record.price.currency_iso).to eq(currency)
     expect(record.price_usd.value).to eq(3.76)
+    expect(record.price_usd.currency_iso).to eq('USD')
     expect(record.prix.value).to eq(3.21)
+    expect(record.prix.currency_iso).to eq('CAD')
   end
 
   describe 'non-fractional-currencies' do

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe 'MoneyColumn' do
 
   describe 'active record queries' do
     it 'searches for both value and currency when currency_read_only is false' do
+      skip
       MoneyRecord.create(price: Money.new(amount, 'USD'))
       expect(MoneyRecord.find_by(price: money)).to eq(record)
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s(:amount)).to eq("1")
   end
 
+  it "#currency_iso returns the currency iso code" do
+    expect(Money.new(1, 'USD').currency_iso).to eq('USD')
+  end
+
+  it "#currency_iso returns a blank string for no currency" do
+    expect(Money.new(1, Money::NullCurrency.new).currency_iso).to eq('')
+  end
+
   it "as_json as a float with 2 decimal places" do
     expect(@money.as_json).to eq("0.00")
   end


### PR DESCRIPTION
# Why
We want to be able to do search using money objects for money_colums. 
```ruby
total = Money.new(1, 'USD')
Cart.where(total: total).to_sql
#=> "SELECT * FROM `carts` WHERE `total` = 1.0"
```
The decision was made to ignore the currency when doing a query because it is more likely someone will be searching for `Money.zero` or that db record with nil currency would be missing from search results.

# What
At this point `composed_of` is causing more problems than it solves. This PR removes it in favor of a custom implementation. The only thing really missing was the `accessor` to provide the active record hook.
