### PR TITLE
Money column remove composed of

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -51,7 +51,7 @@ class Money
     end
 
     def no_currency?(currency)
-      currency.nil? || currency.empty? || currency.to_s.downcase == 'xxx'
+      currency.nil? || currency.to_s.empty? || currency.to_s.downcase == 'xxx'
     end
   end
 end

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -72,14 +72,26 @@ module MoneyColumn
             write_attribute(column, nil)
             return @money_column_cache[column] = nil
           end
-          money = money.to_money
-          currency_db = Money::Helpers.value_to_currency(currency_object || try(currency_column))
 
-          unless currency_db && currency_db.compatible?(money.currency)
-            Money.deprecate("[money_column] currency mismatch between #{currency_db} and #{money.currency}.")
+          currency_source = currency_iso || try(currency_column)
+          currency_object = Money::Helpers.value_to_currency(currency_source)
+
+          unless money.is_a?(Money)
+            write_attribute(column, money)
+            return @money_column_cache[column] = Money.new(money, currency_object)
           end
+
+          if currency_source && !currency_object.compatible?(money.currency)
+            Money.deprecate("[money_column] currency mismatch between #{currency_object} and #{money.currency}.")
+          end
+
           write_attribute(column, money.value)
-          @money_column_cache[column] = Money.new(money.value, currency_db)
+          if currency_read_only
+            @money_column_cache[column] = Money.new(money.value, currency_object)
+          else
+            write_attribute(currency_column, money.currency.to_s)
+            @money_column_cache[column] = money
+          end
         end
       end
     end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -122,6 +122,19 @@ RSpec.describe 'MoneyColumn' do
     end
   end
 
+  describe 'missing money_column currency arguments' do
+    let(:subject) do
+      class MoneyWithWrongCurrencyArguments < ActiveRecord::Base
+        self.table_name = 'money_records'
+        money_column :price
+      end
+    end
+
+    it 'raises an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError, 'must set one of :currency_column or :currency options')
+    end
+  end
+
   describe 'null currency and validations' do
     let(:currency) { Money::NullCurrency.new }
     let(:subject) { MoneyWithValidation.new(price: money) }

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe 'MoneyColumn' do
     expect(record.price).to eq(Money.new(1.23, 'EUR'))
   end
 
+  it 'writes the currency to the db' do
+    expect(Money).to receive(:deprecate).once
+    record.update(price: Money.new(4, 'JPY'))
+    record.reload
+    expect(record.price.value).to eq(4)
+    expect(record.price.currency.to_s).to eq('JPY')
+  end
+
   it 'duplicating the record keeps the money values' do
     expect(MoneyRecord.new(price: money).clone.price).to eq(money)
     expect(MoneyRecord.new(price: money).dup.price).to eq(money)

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -60,15 +60,21 @@ RSpec.describe 'MoneyColumn' do
   it 'handles legacy support for saving floats' do
     record.update(price: 3.21, prix: 3.21)
     expect(record.price.value).to eq(3.21)
+    expect(record.price.currency.to_s).to eq(currency)
     expect(record.price_usd.value).to eq(3.76)
+    expect(record.price_usd.currency.to_s).to eq('USD')
     expect(record.prix.value).to eq(3.21)
+    expect(record.prix.currency.to_s).to eq('CAD')
   end
 
   it 'handles legacy support for saving string' do
     record.update(price: '3.21', prix: '3.21')
     expect(record.price.value).to eq(3.21)
+    expect(record.price.currency.to_s).to eq(currency)
     expect(record.price_usd.value).to eq(3.76)
+    expect(record.price_usd.currency.to_s).to eq('USD')
     expect(record.prix.value).to eq(3.21)
+    expect(record.prix.currency.to_s).to eq('CAD')
   end
 
   describe 'non-fractional-currencies' do


### PR DESCRIPTION
# Why
Remove `composed_of` in favor of a custom implementation. This makes sure we're always seeing the deprecation warnings correctly. It will also prevent us from updating the currency column with an `''` when saving a float or string instead of a money object.

Subset of https://github.com/Shopify/money/pull/93

# What
- Reduce the amount of logs by only having deprecation warnings when writing a money object. 
- Saving a string or float won't update the currency column
- improved tests