### PR TITLE
money_column coerce_null option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ currency.disambiguate_symbol #=> 'US$'
 
 ### Default Currency
 
-By default `Money` defaults to Money::NullCurrency as its currency. This is a 
+By default `Money` defaults to Money::NullCurrency as its currency. This is a
 global variable that can be changed using:
 
 ``` ruby
@@ -106,7 +106,7 @@ Money::Currency.new("JPY").minor_units  # => 0
 Money::Currency.new("MGA").minor_units  # => 1
 ```
 
-## Storing money
+## Money column
 
 Since money internally uses BigDecimal it's logical to use a `decimal` column
 (or `money` for PostgreSQL) for your database. The `money_column` method can
@@ -121,21 +121,17 @@ end
 
 class Order < ApplicationRecord
   money_column :sub_total, :tax
-end 
-``` 
+end
+```
 
-Because it called [`composed_of`](http://api.rubyonrails.org/classes/ActiveRecord/Aggregations/ClassMethods.html) 
-under the hood, you can use Money objects directly with the AR query interface :
-```ruby
-Order.create(sub_total: Money.new(3.50, 'USD'), tax: Money.new(0.35, 'USD'))
-Order.where(sub_total: Money.new(9.99, 'CAD'))
-``` 
+### Options
 
-`money_column` uses an attribute called 'currency' by default. This can be
-overridden by supplying another column name, e.g.: `currency_column: :other`.
-If your currency is hardcoded and there is no column, set a falsey currency
-column and supply the currency code instead:
-`money_column :price_usd, currency_column: false, currency: 'USD'`
+| option | type |  description |
+| --- | --- |  --- |
+| currency_column | method | column from which to read/write the currency  |
+| currency | string | hardcoded currency value  |
+| currency_read_only | boolean |  when true, `currency_column` won't write the currency back into the db. Must be set to true if `currency_column` is an attr_reader or delegate. Default: false |
+| coerce_null | boolean | when true, a nil value will be returned as Money.zero. Default: false |
 
 You can use multiple `money_column` calls to achieve the desired effects with
 currency on the model or attribute level.

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -26,7 +26,7 @@ module MoneyColumn
     end
 
     module ClassMethods
-      def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false)
+      def money_column(*columns, currency_column: nil, currency: nil, currency_read_only: false, coerce_null: false)
         raise ArgumentError, 'cannot set both currency_column and a fixed currency' if currency && currency_column
 
         if currency
@@ -39,7 +39,7 @@ module MoneyColumn
         end
 
         columns.flatten.each do |column|
-          money_column_reader(column, currency_column, currency_iso)
+          money_column_reader(column, currency_column, currency_iso, coerce_null)
           money_column_writer(column, currency_column, currency_iso, currency_read_only)
         end
       end
@@ -53,10 +53,11 @@ module MoneyColumn
         end
       end
 
-      def money_column_reader(column, currency_column, currency_iso)
+      def money_column_reader(column, currency_column, currency_iso, coerce_null)
         define_method column do
           return @money_column_cache[column] if @money_column_cache[column]
-          return unless value = read_attribute(column)
+          value = read_attribute(column)
+          return if value.nil? && !coerce_null
           iso = currency_iso || try(currency_column)
           @money_column_cache[column] = Money.new(value, iso)
         end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -21,6 +21,12 @@ class MoneyWithReadOnlyCurrency < ActiveRecord::Base
   money_column :price, currency_column: 'currency', currency_read_only: true
 end
 
+class MoneyRecordCoerceNull < ActiveRecord::Base
+  self.table_name = 'money_records'
+  money_column :price, currency_column: 'currency', coerce_null: true
+  money_column :price_usd, currency: 'USD', coerce_null: true
+end
+
 RSpec.describe 'MoneyColumn' do
   let(:amount) { 1.23 }
   let(:currency) { 'EUR' }
@@ -187,11 +193,17 @@ RSpec.describe 'MoneyColumn' do
     end
   end
 
-  describe 'saving null' do
-    it 'returns nil when money value have not been set' do
-      record = MoneyRecord.new(price: nil, price_usd: nil)
+  describe 'coerce_null' do
+    it 'returns nil when money value have not been set and coerce_null is false' do
+      record = MoneyRecord.new(price: nil)
       expect(record.price).to eq(nil)
       expect(record.price_usd).to eq(nil)
+    end
+
+    it 'returns 0$ when money value have not been set and coerce_null is true' do
+      record = MoneyRecordCoerceNull.new(price: nil)
+      expect(record.price.value).to eq(0)
+       expect(record.price_usd.value).to eq(0)
     end
   end
 end


### PR DESCRIPTION
# Why
In some cases nils are undesired and are expected to be 0$. A good use case for this would be taxes. 
https://github.com/Shopify/shopify/issues/121143

# What
- Reader methods return Money.zero if coerce_null is true and the value is nil. 
- Default to `coerce_null: false`