### PR TITLE
Money column with a delegated currency

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -52,6 +52,10 @@ class Money
       other.is_a?(NullCurrency) || eql?(other)
     end
 
+    def no_currency?
+      false
+    end
+
     alias_method :==, :eql?
     alias_method :to_s, :iso_code
   end

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -52,10 +52,6 @@ class Money
       other.is_a?(NullCurrency) || eql?(other)
     end
 
-    def no_currency?
-      false
-    end
-
     alias_method :==, :eql?
     alias_method :to_s, :iso_code
   end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -4,6 +4,7 @@ class Money
 
   attr_reader :value, :subunits, :currency
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
+  def_delegators :currency, :no_currency?
 
   class << self
     attr_accessor :parser, :default_currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -4,7 +4,6 @@ class Money
 
   attr_reader :value, :subunits, :currency
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
-  def_delegators :currency, :no_currency?
 
   class << self
     attr_accessor :parser, :default_currency
@@ -89,6 +88,10 @@ class Money
   def cents
     # Money.deprecate('`money.cents` is deprecated and will be removed in the next major release. Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
     (value * 100).to_i
+  end
+
+  def no_currency?
+    currency.is_a?(NullCurrency)
   end
 
   def -@
@@ -362,6 +365,6 @@ class Money
   end
 
   def calculated_currency(other)
-    currency.is_a?(NullCurrency) ? other : currency
+    no_currency? ? other : currency
   end
 end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -28,7 +28,11 @@ class Money
     def to_s
       ''
     end
-    
+
+    def no_currency?
+      true
+    end
+
     alias_method :==, :eql?
   end
 end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -29,10 +29,6 @@ class Money
       ''
     end
 
-    def no_currency?
-      true
-    end
-
     alias_method :==, :eql?
   end
 end


### PR DESCRIPTION
# Why
Some people may want to use a delegated currency column. In those cases it's possible to get into a race condition between the money object and the associated record. For example
```ruby
class MoneyRecord < ActiveRecord::Base
  belongs_to :delegated_record
  delegate :currency, to: :delegated_record
  money_column :price, currency_column: 'currency', currency_read_only: true
end

record = MoneyRecord.new(price: Money.new(1), delegated_record: DelegatedRecord.new(currency: 'USD'))
#=> Module::DelegationError
# MoneyRecord#currency delegated to delegated_record.currency, but associated_record is nil

# VS

record = MoneyRecord.new(delegated_record: DelegatedRecord.new(currency: 'USD'), price: Money.new(1))
record.price #=> Money.new(1, 'USD')

```
This PR fixes this bug.

NOTE: all this is only needed because we want to show a deprecation warning when currencies are incompatible. This must be done in the writer method (since the reader method will fetch the correct currency). This means that when the currency is not yet available (next on the list of params), we'll not get a deprecation warning even though we should have. Can't think of a way around that since we can't reorder the params being associated to the record on the fly. Not having a deprecation warning is better than raising in this case.

# What

- rescue from `Module::DelegationError` in writer method and assume nil currency
- reader method will read currency and assign it (and take care of memoization)
