### PR TITLE
nice error message on non string currencies

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -9,7 +9,7 @@ class Money
 
     class << self
       def new(currency_iso)
-        raise UnknownCurrency, "Currency can't be blank" if currency_iso.nil? || currency_iso.empty?
+        raise UnknownCurrency, "Currency can't be blank" if currency_iso.nil? || currency_iso.to_s.empty?
         iso = currency_iso.to_s.downcase
         @@loaded_currencies[iso] || @@mutex.synchronize { @@loaded_currencies[iso] = super(iso) }
       end


### PR DESCRIPTION
# Why
`Money.new(1, 1)` should give a nice error instead of 
```
NoMethodError: undefined method `empty?' for #<BigDecimal:55cfcc31b360,'0.5399E2',18(27)>
```

# What
convert currency to string first before looking if it's empty