### PR TITLE
Value to currency helper improvements

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -36,7 +36,7 @@ class Money
       case currency
       when Money::Currency, Money::NullCurrency
         currency
-      else
+      when String, nil
         if no_currency?(currency)
           Money.default_currency
         else
@@ -47,6 +47,8 @@ class Money
             Money::NullCurrency.new
           end
         end
+      else
+        raise ArgumentError, "could not parse as currency #{currency.inspect}"
       end
     end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -82,6 +82,11 @@ RSpec.describe Money::Helpers do
       expect(subject.no_currency?('XXX')).to eq(true)
     end
 
+    it 'raises on invalid object' do
+      expect { subject.value_to_currency(OpenStruct.new(amount: 1)) }.to raise_error(ArgumentError)
+      expect { subject.value_to_currency(1) }.to raise_error(ArgumentError)
+    end
+
     it 'returns true when the currency is nil' do
       expect(subject.no_currency?(nil)).to eq(true)
     end


### PR DESCRIPTION
# What
raise when currency object is not a valid argument (like a Numeric for example), instead of simply showing a deprecation warning and using the null currency.

# Why
The deprecation warning was really only intended to handle invalid currency strings rather than non string objects.
Right now it's possible to do 
```ruby
Money.new(1, 1)  == Money.new(1)
Money.new(1, Money.zero)  == Money.new(1)
```