### PR TITLE
consistent zero

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -9,19 +9,13 @@ class Money
     attr_accessor :parser, :default_currency
 
     def new(value = 0, currency = nil)
-      currency ||= current_currency || default_currency
-
-      if value == 0
-        @@zero_money ||= {}
-        @@zero_money[currency] ||= super(0, currency)
-      else
-        super(value, currency)
-      end
+      return zero if value == 0 && currency.nil?
+      super(value, currency || current_currency || default_currency)
     end
     alias_method :from_amount, :new
 
     def zero
-      new(0, NullCurrency.new)
+      @zero ||= new(0, NullCurrency.new)
     end
     alias_method :empty, :zero
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 RSpec.describe "Money" do
 
-  let (:money) {Money.new(1)}
+  let (:money) { Money.new(1) }
   let (:amount_money) { Money.new(1.23, 'USD') }
   let (:non_fractional_money) { Money.new(1, 'JPY') }
   let (:zero_money) { Money.new(0) }


### PR DESCRIPTION
# Why
It is possible to have `Money.new(0) != Money.zero` because a no null default currency is used. This can lead to some confusion. We still want the ability to have Money.new(0, 'USD') which is used during computations that sum to 0.

# What
- Make `Money.new(0)` and `Money.zero` have the exact same behavior
- Allow explicit `Money.new(0, 'USD')`
- Allow zero sum computation to retain currency `Money.new(1, 'USD') - Money.new(1, 'USD') == Money.new(0, 'USD')`