### PR TITLE
active record type serialization

### DIFF
--- a/lib/money_column.rb
+++ b/lib/money_column.rb
@@ -1,2 +1,3 @@
 require_relative 'money_column/active_record_hooks'
+require_relative 'money_column/active_record_type'
 require_relative 'money_column/railtie'

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -39,6 +39,7 @@ module MoneyColumn
         end
 
         columns.flatten.each do |column|
+          attribute(column.to_s, MoneyColumn::ActiveRecordType.new)
           money_column_reader(column, currency_column, currency_iso, coerce_null)
           money_column_writer(column, currency_column, currency_iso, currency_read_only)
         end

--- a/lib/money_column/active_record_type.rb
+++ b/lib/money_column/active_record_type.rb
@@ -1,0 +1,6 @@
+class MoneyColumn::ActiveRecordType < ActiveRecord::Type::Decimal
+  def serialize(money)
+    return nil unless money
+    super(money.to_d)
+  end
+end


### PR DESCRIPTION
# Why
We want to be able to do, without having to get the decimal value first
```ruby
Record.where(price: Money.new(1, 'USD'))
```

# What
- it will automagically convert money object to decimal for searching on the DB
- it will **NOT** search for the currency

# Notes

This change is only compatible with Rails 5+