### PR TITLE
round values being passed to money column

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -70,13 +70,15 @@ module MoneyColumn
           if money.blank?
             write_attribute(column, nil)
             return nil
-          elsif !money.is_a?(Money)
-            return write_attribute(column, money)
           end
 
           currency_raw_source = currency_iso || (send(currency_column) rescue nil)
-
           currency_source = Money::Helpers.value_to_currency(currency_raw_source)
+
+          if !money.is_a?(Money)
+            return write_attribute(column, Money.new(money, currency_source).value)
+          end
+
           if currency_raw_source && !currency_source.compatible?(money.currency)
             Money.deprecate("[money_column] currency mismatch between #{currency_source} and #{money.currency}.")
           end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'MoneyColumn' do
   let(:toonie) { Money.new(2.00, 'CAD') }
   let(:subject) { MoneyRecord.new(price: money, prix: toonie) }
   let(:record) do
+    subject.devise = 'CAD'
     subject.save
     subject.reload
   end
@@ -89,6 +90,16 @@ RSpec.describe 'MoneyColumn' do
     expect(record.price_usd.value).to eq(3.76)
     expect(record.price_usd.currency.to_s).to eq('USD')
     expect(record.prix.value).to eq(3.21)
+    expect(record.prix.currency.to_s).to eq('CAD')
+  end
+
+  it 'handles legacy support for saving floats with correct currency rounding' do
+    record.update(price: 3.2112, prix: 3.2156)
+    expect(record.attributes['price']).to eq(3.21)
+    expect(record.price.value).to eq(3.21)
+    expect(record.price.currency.to_s).to eq(currency)
+    expect(record.attributes['prix']).to eq(3.22)
+    expect(record.prix.value).to eq(3.22)
     expect(record.prix.currency.to_s).to eq('CAD')
   end
 


### PR DESCRIPTION
# Why
The old column requirement was `decimal(10,2)`. This means that any value with more decimal places would get truncated and give a `MysqlWarning` (or similar). In order to prevent these warnings, any non-money value will get rounded

# What
round non-money object being saved to a money column to the number of decimals supported by the currency already in the DB