### PR TITLE
build rational with two money objects

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -39,6 +39,13 @@ class Money
       new(value, currency)
     end
 
+    def rational(money1, money2)
+      money1.send(:arithmetic, money2) do
+        factor = money1.currency.subunit_to_unit * money2.currency.subunit_to_unit
+        Rational((money1.value * factor).to_i, (money2.value * factor).to_i)
+      end
+    end
+
     def current_currency
       Thread.current[:money_currency]
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -295,6 +295,12 @@ RSpec.describe "Money" do
     expect(Money.new(21).floor).to eq(Money.new(21))
   end
 
+  it "generates a true rational" do
+    expect(Money.rational(Money.new(10.0), Money.new(15.0))).to eq(Rational(2,3))
+    expect(Money).to receive(:deprecate).once
+    expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'JPY'))).to eq(Rational(2,3))
+  end
+
   describe "frozen with amount of $1" do
     let (:money) { Money.new(1.00) }
 


### PR DESCRIPTION
# Why
Can't use decimals (they give an approximation)
```ruby
     Failure/Error: expect(Rational(Money.new(10.0).value, Money.new(15.0).value)).to eq(Rational(2,3))

       expected: (2/3)
            got: 0.666666666666666667 (#<BigDecimal:7fbc4594b408,'0.6666666666 66666667E0',18(36)>)
```
AND
can't use `subunits` because they are currency aware
```ruby
     Failure/Error: expect(Rational(Money.new(10.0, 'USD').subunits, Money.new(15.0, 'JPY').subunits)).to eq(Rational(2,3))

       expected: (2/3)
            got: (200/3)
```
https://github.com/Shopify/shopify/issues/121143
# What
- new `Money.rational(money1, money2)` method to correctly handle any currency