### PR TITLE
allocate between money with and without currency

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -499,6 +499,22 @@ RSpec.describe "Money" do
       ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
     end
 
+    specify "#allocate_max_amounts legal computation with no currency objects" do
+      expect(
+        Money.new(3075, 'JPY').allocate_max_amounts([2600, 475]),
+      ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
+
+      expect(
+        Money.new(3075, Money::NullCurrency.new).allocate_max_amounts([Money.new(2600, 'JPY'), Money.new(475, 'JPY')]),
+      ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
+    end
+
+    specify "#allocate_max_amounts illegal computation across currencies" do
+      expect {
+        Money.new(3075, 'USD').allocate_max_amounts([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
+      }.to raise_error(ArgumentError)
+    end
+
     specify "#allocate_max_amounts drops the remainder when returning the weighted allocation without exceeding the maxima when there is no room for the remainder" do
       expect(
         Money.new(30.75).allocate_max_amounts([Money.new(26), Money.new(4.74)]),


### PR DESCRIPTION
# Why
We need to handle cases where we're `allocate_max_amounts` with a money objects that have no currency while the money being allocated does (and vice versa)
https://github.com/Shopify/shopify/issues/121143

# What
- when maximum amounts are integers or have no currency, correctly use the same currency as the allocated amount
- when the amount being allocated doesn't have a currency, use the currency from the max amount (if all max amounts are in the same currency)
- when there is a missmatch of currencies, raise an argument error