### PR TITLE
add null currency constant

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -44,7 +44,7 @@ class Money
             Currency.find!(currency)
           rescue Money::Currency::UnknownCurrency => error
             Money.deprecate(error.message)
-            Money::NullCurrency.new
+            Money::NULL_CURRENCY
           end
         end
       else

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -2,6 +2,8 @@ class Money
   include Comparable
   extend Forwardable
 
+  NULL_CURRENCY = NullCurrency.new.freeze
+
   attr_reader :value, :subunits, :currency
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
 
@@ -21,7 +23,7 @@ class Money
     alias_method :from_amount, :new
 
     def zero
-      new(0, NullCurrency.new)
+      new(0, NULL_CURRENCY)
     end
     alias_method :empty, :zero
 
@@ -70,7 +72,7 @@ class Money
 
     def default_settings
       self.parser = MoneyParser
-      self.default_currency = Money::NullCurrency.new
+      self.default_currency = Money::NULL_CURRENCY
     end
   end
   default_settings
@@ -384,6 +386,6 @@ class Money
     if currencies.size > 1
       raise ArgumentError, "operation not permitted for Money objects with different currencies #{currencies.join(', ')}"
     end
-    currencies.first || NullCurrency.new
+    currencies.first || NULL_CURRENCY
   end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Currency" do
     end
 
     it "returns true for null_currency" do
-      expect(currency.compatible?(Money::NullCurrency.new)).to eq(true)
+      expect(currency.compatible?(Money::NULL_CURRENCY)).to eq(true)
     end
 
     it "returns false for nil" do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Money::Helpers do
   describe 'subject.value_to_currency' do
     it 'returns itself if it is already a currency' do
       expect(subject.value_to_currency(Money::Currency.new('usd'))).to eq(Money::Currency.new('usd'))
-      expect(subject.value_to_currency(Money::NullCurrency.new)).to be_a(Money::NullCurrency)
+      expect(subject.value_to_currency(Money::NULL_CURRENCY)).to be_a(Money::NullCurrency)
     end
 
     it 'returns the default currency when value is nil' do
@@ -72,7 +72,7 @@ RSpec.describe Money::Helpers do
 
     it 'returns the null currency when invalid iso is passed' do
       expect(Money).to receive(:deprecate).once
-      expect(subject.value_to_currency('invalid')).to eq(Money::NullCurrency.new)
+      expect(subject.value_to_currency('invalid')).to eq(Money::NULL_CURRENCY)
     end
   end
 

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe 'MoneyColumn' do
   end
 
   describe 'null currency and validations' do
-    let(:currency) { Money::NullCurrency.new }
+    let(:currency) { Money::NULL_CURRENCY }
     let(:subject) { MoneyWithValidation.new(price: money) }
 
     it 'is not allowed to be saved because `to_s` returns a blank string' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Money" do
   end
 
   it "keeps currency across calculations" do
-    expect(Money.new(1, 'USD') - Money.new(1, 'USD') + Money.new(1.23, Money::NullCurrency.new)).to eq(Money.new(1.23, 'USD'))
+    expect(Money.new(1, 'USD') - Money.new(1, 'USD') + Money.new(1.23, Money::NULL_CURRENCY)).to eq(Money.new(1.23, 'USD'))
   end
 
   it "raises error if added other is not compatible" do
@@ -112,14 +112,14 @@ RSpec.describe "Money" do
 
   it "keeps currency when doing a computation with a null currency" do
     currency = Money.new(10, 'JPY')
-    no_currency = Money.new(1, Money::NullCurrency.new)
+    no_currency = Money.new(1, Money::NULL_CURRENCY)
     expect((no_currency + currency).currency).to eq(Money::Currency.find!('JPY'))
     expect((currency - no_currency).currency).to eq(Money::Currency.find!('JPY'))
   end
 
   it "does not log a deprecation warning when adding with a null currency value" do
     currency = Money.new(10, 'USD')
-    no_currency = Money.new(1, Money::NullCurrency.new)
+    no_currency = Money.new(1, Money::NULL_CURRENCY)
     expect(Money).not_to receive(:deprecate)
     expect(no_currency + currency).to eq(Money.new(11, 'USD'))
     expect(currency - no_currency).to eq(Money.new(9, 'USD'))
@@ -346,8 +346,8 @@ RSpec.describe "Money" do
     end
 
     it "<=> can compare with and without currency" do
-      expect(Money.new(1000, Money::NullCurrency.new) <=> Money.new(2000, 'JPY')).to eq(-1)
-      expect(Money.new(2000, 'JPY') <=> Money.new(1000, Money::NullCurrency.new)).to eq(1)
+      expect(Money.new(1000, Money::NULL_CURRENCY) <=> Money.new(2000, 'JPY')).to eq(-1)
+      expect(Money.new(2000, 'JPY') <=> Money.new(1000, Money::NULL_CURRENCY)).to eq(1)
     end
 
     it "<=> issues deprecation warning when comparing incompatible currency" do
@@ -505,7 +505,7 @@ RSpec.describe "Money" do
       ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
 
       expect(
-        Money.new(3075, Money::NullCurrency.new).allocate_max_amounts([Money.new(2600, 'JPY'), Money.new(475, 'JPY')]),
+        Money.new(3075, Money::NULL_CURRENCY).allocate_max_amounts([Money.new(2600, 'JPY'), Money.new(475, 'JPY')]),
       ).to eq([Money.new(2600, 'JPY'), Money.new(475, 'JPY')])
     end
 
@@ -706,7 +706,7 @@ RSpec.describe "Money" do
           value: !ruby/object:BigDecimal 27:0.6935E2
           cents: 6935
       EOS
-      expect(money).to eq(Money.new(69.35, Money::NullCurrency.new))
+      expect(money).to eq(Money.new(69.35, Money::NULL_CURRENCY))
     end
 
     it "accepts BigDecimal values" do
@@ -767,7 +767,7 @@ RSpec.describe "Money" do
 
     context "with .default_currency set" do
       before(:each) { Money.default_currency = Money::Currency.new('EUR') }
-      after(:each) { Money.default_currency = Money::NullCurrency.new }
+      after(:each) { Money.default_currency = Money::NULL_CURRENCY }
 
       it "can be nested and falls back to default_currency outside of the blocks" do
         money2, money3 = nil

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "NullCurrency" do
-  let (:null_currency) {Money::NullCurrency.new}
+  let (:null_currency) {Money::NULL_CURRENCY}
 
   it 'exposes the same public interface as Currency' do
     expect(Money::NullCurrency).to quack_like Money::Currency
@@ -36,7 +36,7 @@ RSpec.describe "NullCurrency" do
     end
 
     it "returns true for null_currency" do
-      expect(null_currency.compatible?(Money::NullCurrency.new)).to eq(true)
+      expect(null_currency.compatible?(Money::NULL_CURRENCY)).to eq(true)
     end
 
     it "returns false for nil" do


### PR DESCRIPTION
# Why
to avoid creating new instances when it’s not needed

# What
add a `Money::NULL_CURRENCY` constant