### PR TITLE
Added fractional? and non_fractional? to Money::Currency

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -58,5 +58,9 @@ class Money
     def fractional?
       @subunit_to_unit != 1
     end
+
+    def non_fractional?
+      !fractional?
+    end
   end
 end

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -54,5 +54,9 @@ class Money
 
     alias_method :==, :eql?
     alias_method :to_s, :iso_code
+
+    def fractional?
+      @subunit_to_unit != 1
+    end
   end
 end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -29,6 +29,10 @@ class Money
       ''
     end
 
+    def fractional?
+      true
+    end
+
     alias_method :==, :eql?
   end
 end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -33,6 +33,10 @@ class Money
       true
     end
 
+    def non_fractional?
+      false
+    end
+
     alias_method :==, :eql?
   end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -119,4 +119,14 @@ RSpec.describe "Currency" do
       expect(Money::Currency.new('JPY').fractional?).to eq(false)
     end
   end
+
+  describe "#non_fractional?" do
+    it "returns false when currency does use cents" do
+      expect(Money::Currency.new('USD').non_fractional?).to eq(false)
+    end
+
+    it "returns true when currency does not use cents" do
+      expect(Money::Currency.new('JPY').non_fractional?).to eq(true)
+    end
+  end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -109,4 +109,14 @@ RSpec.describe "Currency" do
       expect(currency.compatible?(Money::Currency.new('JPY'))).to eq(false)
     end
   end
+
+  describe "#fractional?" do
+    it "returns true when currency does use cents" do
+      expect(Money::Currency.new('USD').fractional?).to eq(true)
+    end
+
+    it "returns false when currency does not use cents" do
+      expect(Money::Currency.new('JPY').fractional?).to eq(false)
+    end
+  end
 end

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe "NullCurrency" do
       expect(null_currency.compatible?(nil)).to eq(false)
     end
   end
+
+  describe "#fractional?" do
+    it "returns false when currency does not use cents" do
+      expect(null_currency.fractional?).to eq(true)
+    end
+  end
 end

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -45,8 +45,14 @@ RSpec.describe "NullCurrency" do
   end
 
   describe "#fractional?" do
-    it "returns false when currency does not use cents" do
+    it "returns true when currency does not use cents" do
       expect(null_currency.fractional?).to eq(true)
+    end
+  end
+
+  describe "#non_fractional?" do
+    it "returns false when currency does not use cents" do
+      expect(null_currency.non_fractional?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
~~@bdewater this is was I was taking about in https://github.com/Shopify/shopify/pull/131505~~

This started off a conversation/suggestion in PR https://github.com/Shopify/shopify/pull/131505. The idea is to provide these two helper methods that will make refactoring easier across Shopify core code base, wherever we use the money gem.