### PR TITLE
Show precision appropriate for currency when calling #inspect

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -137,7 +137,7 @@ class Money
   end
 
   def inspect
-    "#<#{self.class} value:#{self.to_s} currency:#{self.currency}>"
+    "#<#{self.class} value:#{self.to_s(:amount)} currency:#{self.currency}>"
   end
 
   def ==(other)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe "Money" do
 
   it "#inspects to a presentable string" do
     expect(money.inspect).to eq("#<Money value:1.00 currency:CAD>")
+    expect(Money.new(1, 'JPY').inspect).to eq("#<Money value:1 currency:JPY>")
+    expect(Money.new(1, 'JOD').inspect).to eq("#<Money value:1.000 currency:JOD>")
   end
 
   it "is inspectable within an array" do


### PR DESCRIPTION
As @dylanahsmith noted it's weird that the precision is truncated for three decimal currencies.