### PR TITLE
to_s with correct number of decimals based on currency

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -137,7 +137,7 @@ class Money
   end
 
   def inspect
-    "#<#{self.class} value:#{self.to_s(:amount)} currency:#{self.currency}>"
+    "#<#{self.class} value:#{self} currency:#{self.currency}>"
   end
 
   def ==(other)
@@ -190,9 +190,9 @@ class Money
 
   def to_s(style = nil)
     case style
-    when :legacy_dollars, nil
+    when :legacy_dollars
       sprintf("%.2f", value)
-    when :amount
+    when :amount, nil
       sprintf("%.#{currency.minor_units}f", value)
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe "Money" do
     end
   end
 
-  it "to_s as a float with 2 decimal places" do
+  it "to_s correctly displays the right number of decimal places" do
     expect(money.to_s).to eq("1.00")
+    expect(non_fractional_money.to_s).to eq("1")
   end
 
   it "to_s with a legacy_dollars style" do


### PR DESCRIPTION
# Why
Follow up from https://github.com/Shopify/money/pull/115

Now that money is currency aware, we want
```ruby
Money.new(1, 'USD').to_s #=> '1.00'
Money.new(1, 'USD')      #=> #<Money value:1.00 currency:USD>
Money.new(1, 'JPY').to_s #=> '1'
Money.new(1, 'JPY')      #=> #<Money value:1 currency:JPY>
```

Re: https://github.com/Shopify/shopify/issues/121143

# What
Change the default string representation which also changes how `inspect` displays the result

# Note
It's still possible to get the old behavior by using `to_s(:legacy_dollars)`