### PR TITLE
clamp can take params out of order

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -335,12 +335,10 @@ class Money
   # closest min or max value.
   #
   # @example
-  #   Money.new(50, "CAD").clamp(1, 100) #=> Money.new(10, "CAD")
+  #   Money.new(50, "CAD").clamp(1, 100) #=> Money.new(50, "CAD")
   #
   #   Money.new(120, "CAD").clamp(0, 100) #=> Money.new(100, "CAD")
   def clamp(min, max)
-    raise ArgumentError, 'min cannot be greater than max' if min > max
-
     clamped_value = [min, self.value, max].sort[1]
     if self.value == clamped_value
       self

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -803,14 +803,20 @@ RSpec.describe "Money" do
 
     it 'returns the max value if the original value is larger' do
       money = Money.new(9001, 'EUR').clamp(min, max)
-      expect(money.clamp(min, max).value).to eq(9000)
-      expect(money.clamp(min, max).currency.iso_code).to eq('EUR')
+      expect(money.value).to eq(9000)
+      expect(money.currency.iso_code).to eq('EUR')
     end
 
     it 'returns the min value if the original value is smaller' do
       money = Money.new(-9001, 'EUR').clamp(min, max)
       expect(money.value).to eq(-9000)
       expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'works the same if min max values are inverted' do
+      expect(Money.new(5000, 'EUR').clamp(max, min)).to eq(Money.new(5000, 'EUR'))
+      expect(Money.new(-9001, 'EUR').clamp(max, min)).to eq(Money.new(-9000, 'EUR'))
+      expect(Money.new(9001, 'EUR').clamp(max, min)).to eq(Money.new(9000, 'EUR'))
     end
   end
 end


### PR DESCRIPTION
# Why

It's possible for code to mixup the min and max params to the clamp method. There's no reason to raise in this case since the clamp will work just as well.

```ruby
money.clamp(max, min)
# vs
money.clamp(min, max)
```

# What 
- remove raise if params are out not sorted
- improve tests
