### PR TITLE
namespace the deprecation warnings

### DIFF
--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -7,7 +7,7 @@ Money.class_eval do
 
   def self.deprecate(message)
     if ACTIVE_SUPPORT_DEFINED
-      active_support_deprecator.warn("#{message}\n")
+      active_support_deprecator.warn("[Shopify/Money] #{message}\n")
     else
       Kernel.warn("DEPRECATION WARNING: [Shopify/Money] #{message}\n")
     end


### PR DESCRIPTION
# Why
We want it to be easy to differentiate Money deprecation warnings from other gems

# What
add `[Shopify/Money]` to the beginning of the message