### PR TITLE
allow number strings with whitespace padding

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -4,7 +4,7 @@ class Money
   module Helpers
     extend self
 
-    NUMERIC_REGEX = /\A-?\d*\.?\d*\z/.freeze
+    NUMERIC_REGEX = /\A\s*-?\d*\.?\d*\s*\z/
     DECIMAL_ZERO = BigDecimal.new(0).freeze
 
     def value_to_decimal(num)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -34,9 +34,21 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_decimal('1.23')).to eq(amount)
     end
 
+    it 'returns the bigdecimal version of a ruby number string with whitespace padding' do
+      expect(subject.value_to_decimal(' 1.23 ')).to eq(amount)
+      expect(subject.value_to_decimal("1.23\n")).to eq(amount)
+      expect(subject.value_to_decimal(' -1.23 ')).to eq(-amount)
+    end
+
     it 'invalid string returns zero' do
       expect(Money).to receive(:deprecate).once
       expect(subject.value_to_decimal('invalid')).to eq(0)
+    end
+
+    it 'returns the bigdecimal representation of numbers while they are deprecated' do
+      expect(Money).to receive(:deprecate).exactly(2).times
+      expect(subject.value_to_decimal('1.23abc')).to eq(amount)
+      expect(subject.value_to_decimal("1.23\n23")).to eq(amount)
     end
 
     it 'raises on invalid object' do


### PR DESCRIPTION
# Why
`BigDecimal` correctly handles strings with whitespace padding therefore there's no reason to deprecate that as an invalid string.

```ruby
> BigDecimal.new(' 1.23 ').to_f
=> 1.23
```

# What
add any number of space `/s*` to the numeric validation regex