### PR TITLE
exclude the money gem files from the deprecation call stack

### DIFF
--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -7,7 +7,10 @@ Money.class_eval do
 
   def self.deprecate(message)
     if ACTIVE_SUPPORT_DEFINED
-      active_support_deprecator.warn("[Shopify/Money] #{message}\n")
+      external_callstack = caller_locations.reject do |location|
+        location.to_s.include?('gems/money')
+      end
+      active_support_deprecator.warn("[Shopify/Money] #{message}\n", external_callstack)
     else
       Kernel.warn("DEPRECATION WARNING: [Shopify/Money] #{message}\n")
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -747,6 +747,14 @@ RSpec.describe "Money" do
       expect_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).once
       Money.deprecate('ok')
     end
+
+    it "only sends a callstack of events outside of the money gem" do
+      expect_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(
+        -> (message) { message == "[Shopify/Money] message\n" },
+        -> (callstack) { !callstack.first.to_s.include?('gems/money') && callstack.size > 0 }
+      )
+      Money.deprecate('message')
+    end
   end
 
   describe '#use_currency' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe "Money" do
   end
 
   it "defaults to 0 when constructed with an invalid string" do
-    Money.active_support_deprecator.silence do
-      expect(Money.new('invalid')).to eq(Money.new(0.00))
-    end
+    expect(Money).to receive(:deprecate).once
+    expect(Money.new('invalid')).to eq(Money.new(0.00))
   end
 
   it "to_s correctly displays the right number of decimal places" do
@@ -239,9 +238,7 @@ RSpec.describe "Money" do
   end
 
   it "returns cents in to_liquid" do
-    Money.active_support_deprecator.silence do
-      expect(Money.new(1.00).to_liquid).to eq(100)
-    end
+    expect(Money.new(1.00).to_liquid).to eq(100)
   end
 
   it "returns cents in to_json" do
@@ -413,9 +410,7 @@ RSpec.describe "Money" do
     end
 
     it "returns cents as 100 cents" do
-      Money.active_support_deprecator.silence do
-        expect(money.cents).to eq(100)
-      end
+      expect(money.cents).to eq(100)
     end
 
     it "returns cents as 100 cents" do


### PR DESCRIPTION
# Why
Getting a deprecation warning that points back to the money gem is not useful. Since Rails only shows a single line (by default the before last event `caller_locations(2)`) we need to make sure that location is outside of the Money gem.

# What
Exclude all the money gem locations from the callstack sent to the deprecator `warn` method https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/reporting.rb#L18