### PR TITLE
eql? returns false when currency is not compatible

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -146,9 +146,8 @@ class Money
 
   def eql?(other)
     return false unless other.is_a?(Money)
-    arithmetic(other) do |money|
-      value == money.value
-    end
+    return false unless currency.compatible?(other.currency)
+    value == other.value
   end
 
   class ReverseOperationProxy

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -146,6 +146,16 @@ RSpec.describe "Money" do
 
   it "correctly support eql? as a value object" do
     expect(money).to eq(Money.new(1))
+    expect(money).to eq(Money.new(1, 'CAD'))
+  end
+
+  it "does not eql? with a non money object" do
+    expect(money).to_not eq(1)
+    expect(money).to_not eq(OpenStruct.new(value: 1))
+  end
+
+  it "does not eql? when currency missmatch" do
+    expect(money).to_not eq(Money.new(1, 'JPY'))
   end
 
   it "is addable with integer" do


### PR DESCRIPTION
# Why
Money objects with different currencies should not be equal. 

# What
- support equality with money that has no currency (only checkout amount)
- return false otherwise if currencies missmatch
- add test for legacy behavior of returning false if trying to eql with a non money object