### PR TITLE
Add MissingCurrency that always raises to force using a real currency

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -11,7 +11,7 @@ class Money
     attr_accessor :parser, :default_currency
 
     def new(value = 0, currency = nil)
-      currency ||= current_currency || default_currency
+      currency ||= resolve_currency
 
       if value == 0
         @@zero_money ||= {}
@@ -73,6 +73,12 @@ class Money
     def default_settings
       self.parser = MoneyParser
       self.default_currency = Money::NULL_CURRENCY
+    end
+
+    private
+
+    def resolve_currency
+      current_currency || default_currency || raise(ArgumentError, 'missing currency')
     end
   end
   default_settings

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe "Money" do
     expect(Money.empty).to eq(Money.new)
   end
 
+  context "default currency not set" do
+    before(:each) { Money.default_currency = nil }
+    after(:each) { Money.default_currency = Money::NULL_CURRENCY }
+
+    it "raises an error" do
+      expect { money }.to raise_error(ArgumentError)
+    end
+  end
+
   it ".zero has no currency" do
     expect(Money.zero.currency).to be_a(Money::NullCurrency)
   end


### PR DESCRIPTION
Less magic, more explosions 💥  by setting this as the default, people must pass currency as the second argument to `Money.new` or use a `Money.with_currency` block.

Next step after this PR will be to make it the default of the gem and adjust tests to cover three major currencies (CAD, JPY, JOD) in every spec so we're sure we've covered all common exponents (2, 0, 3 respectively), as discussed IRL.