### PR TITLE
Money parser refactor

### DIFF
--- a/lib/money/accounting_money_parser.rb
+++ b/lib/money/accounting_money_parser.rb
@@ -1,7 +1,7 @@
 class AccountingMoneyParser < MoneyParser
   private
-  def extract_money(input)
+  def extract_money(input, currency = nil)
     # set () to mean negativity. ignore $
-    super(input.gsub(/\(\$?(.*?)\)/, '-\1'))
+    super(input.gsub(/\(\$?(.*?)\)/, '-\1'), currency)
   end
 end

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -27,7 +27,7 @@ class Money
     end
 
     attr_reader :iso_code, :iso_numeric, :name, :smallest_denomination, :subunit_symbol,
-                :subunit_to_unit, :minor_units, :symbol, :disambiguate_symbol
+                :subunit_to_unit, :minor_units, :symbol, :disambiguate_symbol, :decimal_mark
 
     def initialize(currency_iso)
       data = self.class.currencies[currency_iso]
@@ -40,6 +40,7 @@ class Money
       @name                  = data['name']
       @smallest_denomination = data['smallest_denomination']
       @subunit_to_unit       = data['subunit_to_unit']
+      @decimal_mark          = data['decimal_mark']
       @minor_units           = subunit_to_unit == 0 ? 0 : Math.log(subunit_to_unit, 10).round.to_i
       freeze
     end

--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -1,31 +1,65 @@
+# Parse an amount from a string
 class MoneyParser
-  # parse a amount from a string
+  MARKS = "\.,·’"
+  EXTRA_MARKS = "\s˙'"
+
   def self.parse(input, currency = nil)
     new.parse(input, currency)
   end
 
   def parse(input, currency = nil)
-    Money.new(extract_money(input.to_s), currency)
+    amount = extract_money(input.to_s, currency)
+    Money.new(amount, currency)
   end
 
   private
-  def extract_money(input)
-    return Money.zero if input.to_s.empty?
 
-    amount = input.scan(/\-?[\d\.\,]+/).first
+  def extract_money(input, currency)
+    return '0' if input.empty?
 
-    return Money.zero if amount.nil?
+    amount = input.scan(/(-?[\d#{MARKS}][\d#{MARKS}#{EXTRA_MARKS}]*)/).first
+    return '0' unless amount
+    amount = amount.first.tr(EXTRA_MARKS, '')
 
-    # Convert 0.123 or 0,123 into what will be parsed as a decimal amount 0.12 or 0.13
-    amount.gsub!(/^(-)?(0[,.]\d\d)\d+$/, '\1\2')
+    *other_marks, last_mark = amount.scan(/[#{MARKS}]/)
+    return amount unless last_mark
 
-    segments = amount.scan(/^(.*?)(?:[\.\,](\d{1,2}))?$/).first
+    *dollars, cents = amount.split(last_mark)
+    dollars = dollars.join.tr(MARKS, '')
 
-    return Money.zero if segments.empty?
+    if last_digits_decimals?(dollars, cents, last_mark, other_marks, currency)
+      "#{dollars}.#{cents}"
+    else
+      "#{dollars}#{cents}"
+    end
+  end
 
-    amount   = segments[0].gsub(/[^-\d]/, '')
-    decimals = segments[1].to_s.ljust(2, '0')
+  def last_digits_decimals?(first_digits, last_digits, last_mark, other_marks, currency)
+    # Thousands marks are always different from decimal marks
+    # Example: 1,234,456
+    other_marks.uniq!
+    if other_marks.size == 1
+      return other_marks.first != last_mark
+    end
 
-    "#{amount}.#{decimals}"
+    # Thousands always have more than 2 digits
+    # Example: 1,23 must be 1 dollar and 23 cents
+    if last_digits.size < 3
+      return true
+    end
+
+    # 0 before the final mark indicates last digits are decimals
+    # Example: 0,23
+    if first_digits.to_i.zero?
+      return true
+    end
+
+    # The last mark matches the one used by the provided currency to delimiter decimals
+    if currency
+      return Money::Helpers.value_to_currency(currency).decimal_mark == last_mark
+    end
+
+    # legacy support for 1.000
+    last_digits.size != 3
   end
 end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -2,7 +2,7 @@ class Money
   class NullCurrency
 
     attr_reader :iso_code, :iso_numeric, :name, :smallest_denomination, :subunit_symbol,
-                :subunit_to_unit, :minor_units, :symbol, :disambiguate_symbol
+                :subunit_to_unit, :minor_units, :symbol, :disambiguate_symbol, :decimal_mark
 
     def initialize
       @symbol                = '$'
@@ -14,6 +14,7 @@ class Money
       @smallest_denomination = 1
       @subunit_to_unit       = 100
       @minor_units           = 2
+      @decimal_mark          = '.'
       freeze
     end
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Currency" do
     "minor_units": 2,
     "symbol": '$',
     "disambiguate_symbol": "US$",
-    "subunit_symbol": "¢"
+    "subunit_symbol": "¢",
+    "decimal_mark": ".",
   }
 
   let(:currency) { Money::Currency.new('usd') }

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -1,47 +1,47 @@
 require 'spec_helper'
 
 RSpec.describe MoneyParser do
+  before(:each) do
+    @parser = MoneyParser.new
+  end
+
   describe "parsing of amounts with period decimal separator" do
-    before(:each) do
-      @parser = MoneyParser.new
-    end
-  
     it "parses an empty string to $0" do
-      expect(@parser.parse("")).to eq(Money.new)
+      expect(@parser.parse("")).to eq(Money.zero)
     end
-  
+
     it "parses an invalid string to $0" do
-      expect(@parser.parse("no money")).to eq(Money.new)
+      expect(@parser.parse("no money")).to eq(Money.zero)
     end
-  
+
     it "parses a single digit integer string" do
       expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a double digit integer string" do
       expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
-  
+
     it "parses an integer string amount with a leading $" do
       expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a float string amount" do
       expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
-  
+
     it "parses a float string amount with a leading $" do
       expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
-  
+
     it "parses a float string with a single digit after the decimal" do
       expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
-  
+
     it "parses a float string with two digits after the decimal" do
       expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
-  
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -61,9 +61,21 @@ RSpec.describe MoneyParser do
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
+    end
+
+    it "parses a positive amount with a thousands separator with no decimal" do
+      expect(@parser.parse("1,000")).to eq(Money.new(1_000))
+    end
+
+    it "parses a positive amount with a thousands separator with no decimal with a currency" do
+      expect(@parser.parse("1,000", 'JOD')).to eq(Money.new(1_000, 'JOD'))
+    end
+
+    it "parses a positive amount with a thousands separator with no decimal" do
+      expect(@parser.parse("12,34,567.89", 'INR')).to eq(Money.new(1_234_567.89, 'INR'))
     end
 
     it "parses negative $1.00" do
@@ -73,29 +85,37 @@ RSpec.describe MoneyParser do
     it "parses a negative cents amount" do
       expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
-    
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple leading - signs" do
       expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple - signs" do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
+    end
+
+    it "parses no currency amount" do
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1.00))
+    end
+
+    it "parses amount with more than 3 decimals correctly" do
+      expect(@parser.parse("1.11111111")).to eq(Money.new(1.11))
+    end
+
+    it "parses amount with multiple consistent thousands delimiters" do
+      expect(@parser.parse("1.111.111")).to eq(Money.new(1_111_111))
     end
   end
 
   describe "parsing of amounts with comma decimal separator" do
-    before(:each) do
-      @parser = MoneyParser.new
-    end
-    
     it "parses dollar amount $1,00 with leading $" do
       expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
@@ -103,7 +123,7 @@ RSpec.describe MoneyParser do
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
       expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
-    
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -111,91 +131,91 @@ RSpec.describe MoneyParser do
     it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
-    
-    it "parses thousands amount" do
-      expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
-    end
-    
+
     it "parses negative hundreds amount" do
       expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
-    
+
     it "parses positive hundreds amount" do
       expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
-    
+
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
-    
+
+    it "parses a positive amount with a thousands separator with no decimal" do
+      expect(@parser.parse("1.000")).to eq(Money.new(1_000))
+    end
+
+    it "parses a positive amount with a thousands dot separator currency and no decimal" do
+      expect(@parser.parse("1.000", 'EUR')).to eq(Money.new(1_000, 'EUR'))
+    end
+
+    it "parses a three digit currency" do
+      expect(@parser.parse("1.000", 'JOD')).to eq(Money.new(1, 'JOD'))
+    end
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
-  
+
   describe "parsing of decimal cents amounts from 0 to 10" do
-    before(:each) do
-      @parser = MoneyParser.new
-    end
-    
     it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
-    
+
     it "parses 50.1" do
       expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
-    
+
     it "parses 50.2" do
       expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
-    
+
     it "parses 50.3" do
       expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
-    
+
     it "parses 50.4" do
       expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
-    
+
     it "parses 50.5" do
       expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
-    
+
     it "parses 50.6" do
       expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
-    
+
     it "parses 50.7" do
       expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
-    
+
     it "parses 50.8" do
       expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
-    
+
     it "parses 50.9" do
       expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
-    
+
     it "parses 50.10" do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end
   end
 
   describe "parsing of fixnum" do
-    before(:each) do
-      @parser = MoneyParser.new
-    end
-    
     it "parses 1" do
       expect(@parser.parse(1)).to eq(Money.new(1))
     end
@@ -206,16 +226,32 @@ RSpec.describe MoneyParser do
   end
 
   describe "parsing of float" do
-    before(:each) do
-      @parser = MoneyParser.new
-    end
-
     it "parses 1.00" do
       expect(@parser.parse(1.00)).to eq(Money.new(1.00))
     end
 
     it "parses 1.32" do
       expect(@parser.parse(1.32)).to eq(Money.new(1.32))
-    end   
+    end
+  end
+
+  describe "parsing with thousands separators" do
+    [
+      '1,234,567.89',
+      '1 234 567.89',
+      '1 234 567,89',
+      '1,234,567·89',
+      '1.234.567,89',
+      '1˙234˙567,89',
+      '12,34,567.89',
+      "1'234'567.89",
+      "1'234'567,89",
+      '1.234.567’89',
+      '123,4567.89',
+      ].each do |number|
+        it "parses #{number}" do
+          expect(@parser.parse(number)).to eq(Money.new(1_234_567.89))
+        end
+      end
   end
 end


### PR DESCRIPTION
# Why
We need a money parser that is currency aware. Passing the currency will now resolve issues with 3 digit currencies.

```ruby
# Before
MoneyParser.parse('1.000') #=> 1000
"1.11111111".to_money.to_f #=> 111111111

# After
MoneyParser.parse('1.000') #=> 1000 (legacy support)
MoneyParser.parse('1.000', 'JOD') #=> 1
MoneyParser.parse('1.000', 'EUR') #=> 1000
"1.11111111".to_money.to_f #=> 1.11
```
fixes #13
Re https://github.com/Shopify/shopify/issues/27704
Re https://github.com/Shopify/shopify/issues/24137
Re https://github.com/Shopify/shopify/issues/134834

# What 
- refactored MoneyParser
- couple of new tests for edge cases
