### PR TITLE
Avoid object allocation in Money.new to compare value to 0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.3.0
+    version: 2.3.3
 
 database:
   override:

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -14,7 +14,7 @@ class Money
           num.value
         when BigDecimal
           num
-        when nil
+        when nil, 0
           DECIMAL_ZERO
         when Integer
           BigDecimal.new(num)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -13,9 +13,10 @@ class Money
     def new(value = 0, currency = nil)
       currency ||= resolve_currency
 
-      if value == 0
+      value = Helpers.value_to_decimal(value)
+      if value.zero?
         @@zero_money ||= {}
-        @@zero_money[currency] ||= super(0, currency)
+        @@zero_money[currency] ||= super(Helpers::DECIMAL_ZERO, currency)
       else
         super(value, currency)
       end
@@ -83,16 +84,16 @@ class Money
   end
   default_settings
 
-  def initialize(value = 0, currency = nil)
-    raise ArgumentError if value.respond_to?(:nan?) && value.nan?
+  def initialize(value, currency)
+    raise ArgumentError if value.nan?
     @currency = Helpers.value_to_currency(currency)
-    @value = Helpers.value_to_decimal(value).round(@currency.minor_units)
+    @value = value.round(@currency.minor_units)
     @subunits = (@value * @currency.subunit_to_unit).to_i
     freeze
   end
 
   def init_with(coder)
-    initialize(coder['value'], coder['currency'])
+    initialize(Helpers.value_to_decimal(coder['value']), coder['currency'])
   end
 
   def encode_with(coder)


### PR DESCRIPTION
## Problem

We were looking at a stackprof object profile for some sales calculations and noticed that there were a lot of money objects being allocated.  Within that I noticed that the `if value == 0` line was allocating objects, since it coerces `0` to a BigDecimal.

## Solution

Use Numeric#zero? to avoid allocating an object.  Since Money accepts non-numeric values and coerces them to a BigDecimal, I moved the coercion before this check so we could call `value.zero?` without a `respond_to?` check.

## Benchmark

benchmark script

```ruby
require 'benchmark'
require 'money'

ZERO = BigDecimal.new(0)
NON_ZERO = BigDecimal.new('1.23')
N = 500000

def bench(value)
  N.times do
    Money.new(value)
  end
end

Benchmark.bmbm do |x|
  x.report('zero') do
    bench(ZERO)
  end
  x.report('non-zero') do
    bench(NON_ZERO)
  end
end
```

output before

```
Rehearsal --------------------------------------------
zero       0.670000   0.010000   0.680000 (  0.669053)
non-zero   1.700000   0.000000   1.700000 (  1.709787)
----------------------------------- total: 2.380000sec

               user     system      total        real
zero       0.650000   0.000000   0.650000 (  0.649809)
non-zero   1.680000   0.010000   1.690000 (  1.684698)
```

after

```
Rehearsal --------------------------------------------
zero       0.430000   0.000000   0.430000 (  0.430436)
non-zero   1.370000   0.010000   1.380000 (  1.379000)
----------------------------------- total: 1.810000sec

               user     system      total        real
zero       0.430000   0.000000   0.430000 (  0.428288)
non-zero   1.390000   0.000000   1.390000 (  1.391024)
```