### PR TITLE
Avoid eagerly calculating subunits when it often isn't used.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -4,7 +4,7 @@ class Money
 
   NULL_CURRENCY = NullCurrency.new.freeze
 
-  attr_reader :value, :subunits, :currency
+  attr_reader :value, :currency
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
 
   class << self
@@ -88,7 +88,6 @@ class Money
     raise ArgumentError if value.nan?
     @currency = Helpers.value_to_currency(currency)
     @value = value.round(@currency.minor_units)
-    @subunits = (@value * @currency.subunit_to_unit).to_i
     freeze
   end
 
@@ -104,6 +103,10 @@ class Money
   def cents
     # Money.deprecate('`money.cents` is deprecated and will be removed in the next major release. Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
     (value * 100).to_i
+  end
+
+  def subunits
+    (@value * @currency.subunit_to_unit).to_i
   end
 
   def no_currency?
@@ -323,6 +326,7 @@ class Money
   #   Money.new(100, "USD").split(3) #=> [Money.new(34), Money.new(33), Money.new(33)]
   def split(num)
     raise ArgumentError, "need at least one party" if num < 1
+    subunits = self.subunits
     low = Money.from_subunits(subunits / num, currency)
     high = Money.from_subunits(low.subunits + 1, currency)
 


### PR DESCRIPTION
## Problem

We are spending a good deal of time during sales calculations in GC and a significant number of the object allocations happen within `Money.new`.  For instance, any arithmetic creates a new money object, but only uses the value for the calculation.

## Solution

Having Money#subunits calculate the value so the calculation isn't performed when it isn't necessary.

I was going to have it memoize the result, but we freeze the Money object on initialization which prevents memoization.  However, I don't think that will cause a problem, since we made the same change with `cents` when it was more heavily used.