### PR TITLE
stricter money parser

### DIFF
--- a/lib/money/accounting_money_parser.rb
+++ b/lib/money/accounting_money_parser.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 class AccountingMoneyParser < MoneyParser
-  private
-  def extract_money(input, currency = nil)
+  def parse(input, currency = nil, **options)
     # set () to mean negativity. ignore $
-    super(input.gsub(/\(\$?(.*?)\)/, '-\1'), currency)
+    super(input.gsub(/\(\$?(.*?)\)/, '-\1'), currency, **options)
   end
 end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -28,8 +28,8 @@ class Money
     end
     alias_method :empty, :zero
 
-    def parse(input, currency = nil)
-      parser.parse(input, currency)
+    def parse(*args)
+      parser.parse(*args)
     end
 
     def from_cents(cents, currency = nil)

--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -77,6 +77,8 @@ class MoneyParser
 
     unless number
       raise MoneyFormatError, "invalid money string: #{input}" if strict
+
+      Money.deprecate("invalid money strings will raise in the next major release \"#{input}\"")
       return '0'
     end
 
@@ -100,6 +102,7 @@ class MoneyParser
 
     raise MoneyFormatError, "invalid money string: #{input}" if strict
 
+    Money.deprecate("invalid money strings will raise in the next major release \"#{input}\"")
     normalize_number(number, marks, currency)
   end
 

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -5,51 +5,52 @@ RSpec.describe AccountingMoneyParser do
     before(:each) do
       @parser = AccountingMoneyParser.new
     end
-    
+
     it "parses parenthesis as a negative amount eg (99.00)" do
       expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00))
     end
-  
+
     it "parses parenthesis as a negative amount regardless of currency sign" do
       expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00))
     end
-  
+
     it "parses an empty string to $0" do
       expect(@parser.parse("")).to eq(Money.new)
     end
-  
+
     it "parses an invalid string to $0" do
+      expect(Money).to receive(:deprecate).once
       expect(@parser.parse("no money")).to eq(Money.new)
     end
-  
+
     it "parses a single digit integer string" do
       expect(@parser.parse("1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a double digit integer string" do
       expect(@parser.parse("10")).to eq(Money.new(10.00))
     end
-  
+
     it "parses an integer string amount with a leading $" do
       expect(@parser.parse("$1")).to eq(Money.new(1.00))
     end
-  
+
     it "parses a float string amount" do
       expect(@parser.parse("1.37")).to eq(Money.new(1.37))
     end
-  
+
     it "parses a float string amount with a leading $" do
       expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
     end
-  
+
     it "parses a float string with a single digit after the decimal" do
       expect(@parser.parse("10.0")).to eq(Money.new(10.00))
     end
-  
+
     it "parses a float string with two digits after the decimal" do
       expect(@parser.parse("10.00")).to eq(Money.new(10.00))
     end
-  
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -69,7 +70,7 @@ RSpec.describe AccountingMoneyParser do
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
     end
@@ -81,19 +82,19 @@ RSpec.describe AccountingMoneyParser do
     it "parses a negative cents amount" do
       expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
     end
-    
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0.123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple leading - signs" do
       expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
     end
-    
+
     it "parses negative amount with multiple - signs" do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
@@ -103,7 +104,7 @@ RSpec.describe AccountingMoneyParser do
     before(:each) do
       @parser = AccountingMoneyParser.new
     end
-    
+
     it "parses dollar amount $1,00 with leading $" do
       expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
     end
@@ -111,7 +112,7 @@ RSpec.describe AccountingMoneyParser do
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
       expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
     end
-    
+
     it "parses the amount from an amount surrounded by whitespace and garbage" do
       expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
     end
@@ -119,81 +120,81 @@ RSpec.describe AccountingMoneyParser do
     it "parses the amount from an amount surrounded by garbage" do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
-    
+
     it "parses thousands amount" do
       expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
     end
-    
+
     it "parses negative hundreds amount" do
       expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
     end
-    
+
     it "parses positive hundreds amount" do
       expect(@parser.parse("410,00")).to eq(Money.new(410.00))
     end
-    
+
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
     end
-  
+
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
     end
-    
+
     it "parses amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("0,123")).to eq(Money.new(0.12))
     end
-    
+
     it "parses negative amount with 3 decimals and 0 dollar amount" do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
   end
-  
+
   describe "parsing of decimal cents amounts from 0 to 10" do
     before(:each) do
       @parser = AccountingMoneyParser.new
     end
-    
+
     it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))
     end
-    
+
     it "parses 50.1" do
       expect(@parser.parse("50.1")).to eq(Money.new(50.10))
     end
-    
+
     it "parses 50.2" do
       expect(@parser.parse("50.2")).to eq(Money.new(50.20))
     end
-    
+
     it "parses 50.3" do
       expect(@parser.parse("50.3")).to eq(Money.new(50.30))
     end
-    
+
     it "parses 50.4" do
       expect(@parser.parse("50.4")).to eq(Money.new(50.40))
     end
-    
+
     it "parses 50.5" do
       expect(@parser.parse("50.5")).to eq(Money.new(50.50))
     end
-    
+
     it "parses 50.6" do
       expect(@parser.parse("50.6")).to eq(Money.new(50.60))
     end
-    
+
     it "parses 50.7" do
       expect(@parser.parse("50.7")).to eq(Money.new(50.70))
     end
-    
+
     it "parses 50.8" do
       expect(@parser.parse("50.8")).to eq(Money.new(50.80))
     end
-    
+
     it "parses 50.9" do
       expect(@parser.parse("50.9")).to eq(Money.new(50.90))
     end
-    
+
     it "parses 50.10" do
       expect(@parser.parse("50.10")).to eq(Money.new(50.10))
     end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses an invalid string to $0" do
+      expect(Money).to receive(:deprecate).once
       expect(@parser.parse("no money")).to eq(Money.zero)
     end
 
@@ -131,6 +132,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
+      expect(Money).to receive(:deprecate).once
       expect(@parser.parse("1.1.11.111")).to eq(Money.new(1_111_111))
     end
 
@@ -193,6 +195,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
+      expect(Money).to receive(:deprecate).once
       expect(@parser.parse("1,1,11,111")).to eq(Money.new(1_111_111))
     end
 


### PR DESCRIPTION
# Why
invalid input into the money parser should raise instead of returning 0$
Blocking Shopify/shopify#136489
Re https://github.com/Shopify/stronger_parameters/pull/43

# What
- make this optional (for now) by making this behavior opt-in with a `strict` option
- strict will raise on non numeric strings
- strict will raise on badly formatted thousand seperators