### PR TITLE
Use string column names for money columns and money currency columns

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -37,11 +37,13 @@ module MoneyColumn
         else
           raise ArgumentError, 'must set one of :currency_column or :currency options'
         end
+        currency_column = currency_column.to_s.freeze
 
         columns.flatten.each do |column|
-          attribute(column.to_s, MoneyColumn::ActiveRecordType.new)
-          money_column_reader(column, currency_column, currency_iso, coerce_null)
-          money_column_writer(column, currency_column, currency_iso, currency_read_only)
+          column_string = column.to_s.freeze
+          attribute(column_string, MoneyColumn::ActiveRecordType.new)
+          money_column_reader(column_string, currency_column, currency_iso, coerce_null)
+          money_column_writer(column_string, currency_column, currency_iso, currency_read_only)
         end
       end
 

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class MoneyRecord < ActiveRecord::Base
   RATE = 1.17
   before_validation do
-    self.price_usd = Money.new(self[:price] * RATE, 'USD') if self[:price]
+    self.price_usd = Money.new(self["price"] * RATE, 'USD') if self["price"]
   end
   money_column :price, currency_column: 'currency'
   money_column :prix, currency_column: :devise
@@ -254,11 +254,11 @@ RSpec.describe 'MoneyColumn' do
 
   describe 'memoization' do
     it 'correctly memoizes the read value' do
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(nil)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(nil)
       price = Money.new(1, 'USD')
       record = MoneyRecord.new(price: price)
       expect(record.price).to eq(price)
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(price)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(price)
     end
 
     it 'memoizes values get reset when writing a new value' do
@@ -268,18 +268,18 @@ RSpec.describe 'MoneyColumn' do
       price = Money.new(2, 'USD')
       record.update!(price: price)
       expect(record.price).to eq(price)
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(price)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(price)
     end
 
     it 'reload will clear memoizes money values' do
       price = Money.new(1, 'USD')
       record = MoneyRecord.create(price: price)
       expect(record.price).to eq(price)
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(price)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(price)
       record.reload
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(nil)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(nil)
       record.price
-      expect(record.instance_variable_get(:@money_column_cache)[:price]).to eq(price)
+      expect(record.instance_variable_get(:@money_column_cache)["price"]).to eq(price)
     end
   end
 


### PR DESCRIPTION
We use Rails' `read_attribute` and `write_attribute` methods to implement money_column stuff, which, in Shopify, is mostly how we get Money objects to work with. In performance critical money-manipulation code, the money column readers and writers actually get invoked a lot, so, we should make them reasonably fast. It turns out that inside `read_attribute` and `write_attribute`, Rails does a lot of string manipulation to check for aliases and index into the actual attributes storage backend. If we pass in a symbol to those methods, the `#to_s` calls that get invoked super often actually end up allocating a remarkable number of strings. If instead we pass strings right into `read_attribute` and `write_attribute`, all those `#to_s` calls are no-ops, so a lot less string garbage is created. So, this change switches the metaprogramming that defines money column methods (and eventually that calls the Rails methods in question) to define using strings instead of symbols, so strings get passed down. It worked! In the Shopify sales ETL, I saw a 60% reduction of immediately garbage collected strings having to do with money manipulation after this change.