### PR TITLE
bigdecimal 1.3.2

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -2,9 +2,9 @@ require 'bigdecimal'
 
 class Money
   module Helpers
-    extend self
+    module_function
 
-    NUMERIC_REGEX = /\A\s*-?\d*\.?\d*\s*\z/
+    NUMERIC_REGEX = /\A\s*[\+\-]?\d*(\.\d*)?\s*\z/
     DECIMAL_ZERO = BigDecimal.new(0).freeze
 
     def value_to_decimal(num)
@@ -21,10 +21,7 @@ class Money
         when Float, Rational
           BigDecimal.new(num, Float::DIG)
         when String
-          if num !~ NUMERIC_REGEX
-            Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
-          end
-          BigDecimal.new(num)
+          string_to_decimal(num)
         else
           raise ArgumentError, "could not parse as decimal #{num.inspect}"
         end
@@ -54,6 +51,19 @@ class Money
 
     def no_currency?(currency)
       currency.nil? || currency.to_s.empty? || currency.to_s.downcase == 'xxx'
+    end
+
+    def string_to_decimal(num)
+      if num =~ NUMERIC_REGEX
+        return BigDecimal.new(num)
+      end
+
+      Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
+      begin
+        BigDecimal.new(num)
+      rescue ArgumentError
+        DECIMAL_ZERO
+      end
     end
   end
 end

--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -73,7 +73,7 @@ class MoneyParser
       return '0'
     end
 
-    number = input.scan(NUMERIC_REGEX).flatten.first.try!(:strip)
+    number = input.scan(NUMERIC_REGEX).flatten.first
 
     unless number
       raise MoneyFormatError, "invalid money string: #{input}" if strict
@@ -82,8 +82,9 @@ class MoneyParser
       return '0'
     end
 
-    marks = number.scan(/[#{ESCAPED_MARKS}]/).flatten
+    number.sub!(/[#{ESCAPED_MARKS}]\z/, '')
 
+    marks = number.scan(/[#{ESCAPED_MARKS}]/).flatten
     if marks.empty?
       return number
     end

--- a/money.gemspec
+++ b/money.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_development_dependency("database_cleaner", "~> 1.6")
   s.add_development_dependency("sqlite3", "~> 1.3")
+  s.add_development_dependency("bigdecimal", ">= 1.3.2")
 
   s.files = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("410")).to eq(Money.new(410.00))
     end
 
+    it "parses an amount ending with a ." do
+      expect(@parser.parse("1.")).to eq(Money.new(1))
+      expect(@parser.parse("100,000.")).to eq(Money.new(100_000))
+    end
+
     it "parses a positive amount with a thousands separator" do
       expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
     end
@@ -172,6 +177,11 @@ RSpec.describe MoneyParser do
 
     it "parses a negative amount with a thousands separator" do
       expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
+    end
+
+    it "parses amount ending with a comma" do
+      expect(@parser.parse("1,")).to eq(Money.new(1))
+      expect(@parser.parse("100.000,")).to eq(Money.new(100_000))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do


### PR DESCRIPTION
# Why
the new big decimal is more strict as to what string values it supports. This commit makes sure nothing breaks

# What
- support for `Money.new('invalid') #=> 0` with a deprecation warning
- support for `Money.new('1.') #=> 1`