### PR TITLE
Money.new handle empty string

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -15,7 +15,7 @@ class Money
           num.value
         when BigDecimal
           num
-        when nil, 0
+        when nil, 0, ''
           DECIMAL_ZERO
         when Integer
           BigDecimal.new(num)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_decimal(nil)).to eq(0)
     end
 
+    it 'returns zero when empty' do
+      expect(subject.value_to_decimal('')).to eq(0)
+    end
+
     it 'returns the bigdecimal version of a integer' do
       expect(subject.value_to_decimal(1)).to eq(BigDecimal.new('1'))
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe "Money" do
     expect(Money.new).to eq(Money.new(0))
   end
 
+  it "defaults to 0 when constructed with an empty string" do
+    expect(Money.new('')).to eq(Money.new(0))
+  end
+
   it "defaults to 0 when constructed with an invalid string" do
     expect(Money).to receive(:deprecate).once
     expect(Money.new('invalid')).to eq(Money.new(0.00))


### PR DESCRIPTION
# Why
Since BigDecimal 1.3.2, empty strings are no longer allowed. We want money to support the legacy behavior

# What
```
Money.new('') == Money.zero
```