### PR TITLE
do not raise when parsing an invalid number

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -5,7 +5,7 @@ class Money
   module Helpers
     module_function
 
-    NUMERIC_REGEX = /\A\s*[\+\-]?\d*(\.\d*)?\s*\z/
+    NUMERIC_REGEX = /\A\s*[\+\-]?\d*(\.\d+)?\s*\z/
     DECIMAL_ZERO = BigDecimal.new(0).freeze
 
     def value_to_decimal(num)

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe MoneyParser do
     end
 
     it "parses an invalid string to $0" do
-      expect(Money).to receive(:deprecate).once
+      expect(Money).to receive(:deprecate).twice
       expect(@parser.parse("no money")).to eq(Money.zero)
+      expect(@parser.parse("1..")).to eq(Money.zero)
     end
 
     it "parses raise with an invalid string and strict option" do
@@ -66,6 +67,10 @@ RSpec.describe MoneyParser do
     it "parses an amount ending with a ." do
       expect(@parser.parse("1.")).to eq(Money.new(1))
       expect(@parser.parse("100,000.")).to eq(Money.new(100_000))
+    end
+
+    it "parses an amount starting with a ." do
+      expect(@parser.parse(".12")).to eq(Money.new(0.12))
     end
 
     it "parses a positive amount with a thousands separator" do


### PR DESCRIPTION
# Why
We want to avoid raising for `"0.."` strings passed to the money parser.
re: https://github.com/Shopify/shopify/issues/137526

# What
do not raise when parsing an invalid number, instead show a deprecation warning and return 0$

