### PR TITLE
Test ensuring currency is preserved when using money_accessor

### DIFF
--- a/spec/money_accessor_spec.rb
+++ b/spec/money_accessor_spec.rb
@@ -73,6 +73,12 @@ end
 
 RSpec.describe NormalObject do
   it_behaves_like "an object with a money accessor"
+
+  it 'preserves the currency value when passed to money_accessor' do
+    object = described_class.new(Money.new(10, 'USD'))
+    currency = Money::Currency.new('USD')
+    expect(object.price.currency).to eq(currency)
+  end
 end
 
 RSpec.describe StructObject do


### PR DESCRIPTION
I think `money_accessor` should probably preserve the currency if you're passing it a `Money` object.