### PR TITLE
have to_json and as_json return amount and currency json

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -214,11 +214,11 @@ class Money
   end
 
   def to_json(options = {})
-    to_s
+    JSON.dump({value: value, currency: currency})
   end
 
   def as_json(*args)
-    to_s
+    to_json
   end
 
   def abs

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -32,6 +32,11 @@ class Money
       parser.parse(*args)
     end
 
+    def from_json(json)
+      data = JSON.parse(json)
+      Money.new(data['value'], data['currency'])
+    end
+
     def from_cents(cents, currency = nil)
       new(cents.round.to_f / 100, currency)
     end
@@ -213,12 +218,8 @@ class Money
     cents
   end
 
-  def to_json(options = {})
-    JSON.dump({value: value, currency: currency})
-  end
-
-  def as_json(*args)
-    to_json
+  def as_json(*_args)
+    { value: to_s(:amount), currency: currency.to_s }
   end
 
   def abs

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s(:amount)).to eq("1")
   end
 
-  it "as_json as a float with 2 decimal places" do
-    expect(money.as_json).to eq("1.00")
+  it "as_json as a json containing the value and currency" do
+    expect(money.as_json).to eq('{"value":"1.0","currency":"CAD"}')
   end
 
   it "is constructable with a BigDecimal" do
@@ -282,8 +282,8 @@ RSpec.describe "Money" do
     expect(Money.new(1.00).to_liquid).to eq(100)
   end
 
-  it "returns cents in to_json" do
-    expect(Money.new(1.00).to_json).to eq("1.00")
+  it "returns in to_json" do
+    expect(Money.new(1.00).to_json).to eq('{"value":"1.0","currency":"CAD"}')
   end
 
   it "supports absolute value" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Money" do
   end
 
   it "as_json as a json containing the value and currency" do
-    expect(money.as_json).to eq('{"value":"1.0","currency":"CAD"}')
+    expect(money.as_json).to eq(value: "1.00", currency: "CAD")
   end
 
   it "is constructable with a BigDecimal" do
@@ -283,7 +283,7 @@ RSpec.describe "Money" do
   end
 
   it "returns in to_json" do
-    expect(Money.new(1.00).to_json).to eq('{"value":"1.0","currency":"CAD"}')
+    expect(Money.new(1.00).to_json).to eq('{"value":"1.00","currency":"CAD"}')
   end
 
   it "supports absolute value" do
@@ -300,6 +300,10 @@ RSpec.describe "Money" do
 
   it "supports to_f" do
     expect(Money.new(1.50).to_f.to_s).to eq("1.5")
+  end
+
+  it "is creatable from a json string" do
+    expect(Money.from_json('{"value":"1.0","currency":"CAD"}')).to eq(Money.new(1, 'CAD'))
   end
 
   it "is creatable from an integer value in cents" do


### PR DESCRIPTION
# Why
Fixes #76

# What
- `as_json` should return a hash of attributes (amount, currency) to be serialized, not a string
- `from_json` is missing to assign attributes from a JSON object