### PR TITLE
parse money strings inside a with_currency block

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -34,16 +34,18 @@ class Money
       case currency
       when Money::Currency, Money::NullCurrency
         currency
-      when String, nil
-        if no_currency?(currency)
-          Money.default_currency
-        else
-          begin
-            Currency.find!(currency)
-          rescue Money::Currency::UnknownCurrency => error
-            Money.deprecate(error.message)
-            Money::NULL_CURRENCY
-          end
+      when nil, ''
+        default = Money.current_currency || Money.default_currency
+        raise(ArgumentError, 'missing currency') if default.nil? || default == ''
+        value_to_currency(default)
+      when 'xxx', 'XXX'
+        Money::NULL_CURRENCY
+      when String
+        begin
+          Currency.find!(currency)
+        rescue Money::Currency::UnknownCurrency => error
+          Money.deprecate(error.message)
+          Money::NULL_CURRENCY
         end
       else
         raise ArgumentError, "could not parse as currency #{currency.inspect}"

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -52,10 +52,6 @@ class Money
       end
     end
 
-    def no_currency?(currency)
-      currency.nil? || currency.to_s.empty? || (currency.to_s.casecmp('xxx') == 0)
-    end
-
     def string_to_decimal(num)
       if num =~ NUMERIC_REGEX
         return BigDecimal.new(num)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -11,12 +11,12 @@ class Money
     attr_accessor :parser, :default_currency
 
     def new(value = 0, currency = nil)
-      currency ||= resolve_currency
-
       value = Helpers.value_to_decimal(value)
+      currency = Helpers.value_to_currency(currency)
+
       if value.zero?
         @@zero_money ||= {}
-        @@zero_money[currency] ||= super(Helpers::DECIMAL_ZERO, currency)
+        @@zero_money[currency.iso_code] ||= super(Helpers::DECIMAL_ZERO, currency)
       else
         super(value, currency)
       end
@@ -74,12 +74,6 @@ class Money
     def default_settings
       self.parser = MoneyParser
       self.default_currency = Money::NULL_CURRENCY
-    end
-
-    private
-
-    def resolve_currency
-      current_currency || default_currency || raise(ArgumentError, 'missing currency')
     end
   end
   default_settings

--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -62,6 +62,7 @@ class MoneyParser
   end
 
   def parse(input, currency = nil, strict: false)
+    currency = Money::Helpers.value_to_currency(currency)
     amount = extract_money(input.to_s, currency, strict)
     Money.new(amount, currency)
   end
@@ -139,8 +140,6 @@ class MoneyParser
       return true
     end
 
-    # The last mark matches the one used by the provided currency to delimiter decimals
-    if currency
       return Money::Helpers.value_to_currency(currency).decimal_mark == last_mark
     end
 

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -122,7 +122,9 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses thousands amount" do
-      expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+      Money.with_currency(Money::NULL_CURRENCY) do
+        expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+      end
     end
 
     it "parses negative hundreds amount" do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -79,7 +79,11 @@ RSpec.describe Money::Helpers do
     end
 
     it 'returns the default currency when value is xxx' do
-      expect(subject.value_to_currency('xxx')).to eq(Money.default_currency)
+      expect(subject.value_to_currency('xxx')).to eq(Money::NULL_CURRENCY)
+    end
+
+    it 'returns the current currency when value is set' do
+      expect(Money.with_currency('USD') { subject.value_to_currency(nil) }).to eq(Money::Currency.find!('usd'))
     end
 
     it 'returns the matching currency' do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -94,29 +94,10 @@ RSpec.describe Money::Helpers do
       expect(Money).to receive(:deprecate).once
       expect(subject.value_to_currency('invalid')).to eq(Money::NULL_CURRENCY)
     end
-  end
-
-  describe 'no_currency?' do
-    it 'returns true when the currency matches a no currency iso code xxx' do
-      expect(subject.no_currency?('xxx')).to eq(true)
-      expect(subject.no_currency?('XXX')).to eq(true)
-    end
 
     it 'raises on invalid object' do
       expect { subject.value_to_currency(OpenStruct.new(amount: 1)) }.to raise_error(ArgumentError)
       expect { subject.value_to_currency(1) }.to raise_error(ArgumentError)
-    end
-
-    it 'returns true when the currency is nil' do
-      expect(subject.no_currency?(nil)).to eq(true)
-    end
-
-    it 'returns true when the currency is an empty string' do
-      expect(subject.no_currency?('')).to eq(true)
-    end
-
-    it 'returns true when the currency does not match a no currency iso code' do
-      expect(subject.no_currency?('usd')).to eq(false)
     end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Money::Helpers do
 
   describe 'subject.value_to_currency' do
     it 'returns itself if it is already a currency' do
-      expect(subject.value_to_currency(Money::Currency.new('usd'))).to eq(Money::Currency.new('usd'))
+      expect(subject.value_to_currency(Money::Currency.new('usd'))).to eq(Money::Currency.find!('usd'))
       expect(subject.value_to_currency(Money::NULL_CURRENCY)).to be_a(Money::NullCurrency)
     end
 

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -129,6 +129,10 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("1.000", 'JOD')).to eq(Money.new(1, 'JOD'))
     end
 
+    it "parses uses currency when passed as block to with_currency" do
+      expect(Money.with_currency('JOD') { @parser.parse("1.000") }).to eq(Money.new(1, 'JOD'))
+    end
+
     it "parses no currency amount" do
       expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1.00))
     end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -10,14 +10,15 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("")).to eq(Money.zero)
     end
 
-    it "parses an invalid string to $0" do
+    it "parses an invalid string when not strict" do
       expect(Money).to receive(:deprecate).twice
       expect(@parser.parse("no money")).to eq(Money.zero)
-      expect(@parser.parse("1..")).to eq(Money.zero)
+      expect(@parser.parse("1..")).to eq(Money.new(1))
     end
 
     it "parses raise with an invalid string and strict option" do
       expect { @parser.parse("no money", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
+      expect { @parser.parse("1..1", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
     end
 
     it "parses a single digit integer string" do
@@ -117,10 +118,6 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
     end
 
-    it "parses a positive amount with a thousands separator with no decimal" do
-      expect(@parser.parse("1.000")).to eq(Money.new(1_000))
-    end
-
     it "parses a positive amount with a thousands dot separator currency and no decimal" do
       expect(@parser.parse("1.000", 'EUR')).to eq(Money.new(1_000, 'EUR'))
     end
@@ -134,7 +131,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses no currency amount" do
-      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1.00))
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1000, Money::NULL_CURRENCY))
     end
 
     it "parses amount with more than 3 decimals correctly" do
@@ -201,8 +198,12 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
     end
 
+    it "parses amount 2 decimals correctly" do
+      expect(@parser.parse("1,11", Money::NULL_CURRENCY)).to eq(Money.new(1.11, Money::NULL_CURRENCY))
+    end
+
     it "parses amount with more than 3 decimals correctly" do
-      expect(@parser.parse("1,11111111")).to eq(Money.new(1.11))
+      expect(@parser.parse("1,11111111", Money::NULL_CURRENCY)).to eq(Money.new(111_111_111, Money::NULL_CURRENCY))
     end
 
     it "parses amount with more than 3 decimals correctly and a currency" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -13,8 +13,13 @@ RSpec.describe "Money" do
   end
 
   context "default currency not set" do
-    before(:each) { Money.default_currency = nil }
-    after(:each) { Money.default_currency = Money::NULL_CURRENCY }
+    before(:each) do
+      @default_currency = Money.default_currency
+      Money.default_currency = nil
+    end
+    after(:each) do
+      Money.default_currency = @default_currency
+    end
 
     it "raises an error" do
       expect { money }.to raise_error(ArgumentError)


### PR DESCRIPTION
# Why
fixes #139 
right now the currency passed to `with_currency` is not respected
```
> Money.with_currency('KWD') { Money.parse("100.000") }
=> #<Money value:100000.000 currency:KWD> #BUG

> Money.parse("100.000", 'KWD')
=> #<Money value:100.000 currency:KWD>
```

# What 
- properly handle parsing a money string within a `with_currency` block
- `value_to_currency` helper now handles looking up the current/default currency
- some `MoneyParser` consistency cleanup
- fix bug in tests where the `default_currency` was not reset correctly
- removed `Money::Helper.no_currency?(currency)` helper since it's no longer used (`money.no_currency?` is still available)

