### PR TITLE
rename gem shopify-money

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ money_column expects a decimal 8,3 database field.
 
 ## Installation
 
-    gem 'money', github: 'shopify/money'
+    gem 'shopify-money', require: 'money'
 
 ## Usage
 

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = "0.1.0"
+  VERSION = "0.10.0"
 end

--- a/money.gemspec
+++ b/money.gemspec
@@ -2,7 +2,7 @@
 require_relative "lib/money/version"
 
 Gem::Specification.new do |s|
-  s.name = "money"
+  s.name = "shopify-money"
   s.version = Money::VERSION
   s.platform = Gem::Platform::RUBY
   s.authors = ["Shopify Inc"]


### PR DESCRIPTION
# Why
We want to push this gem to rubygems. 
Because there is already a `money` gem we need to rename ours. 

# What
- rename gem to `shopify-money`
- update docs to show that now the gem needs to be required with option `require: 'money'`
- bump version to `0.10` 