### PR TITLE
parse to use minor units

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -141,8 +141,7 @@ class MoneyParser
       return true
     end
 
-    # legacy support for 1.000
-    if currency.to_s.empty? && digits.last.size == 3
+    if currency.minor_units < 3 && digits.last.size == 3
       return false
     end
 

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -224,6 +224,45 @@ RSpec.describe MoneyParser do
     end
   end
 
+  describe "3 digit decimal currency" do
+    it "parses thousands correctly" do
+      expect(@parser.parse("1,111", "JOD")).to eq(Money.new(1_111, 'JOD'))
+      expect(@parser.parse("1.111.111", "JOD")).to eq(Money.new(1_111_111, 'JOD'))
+      expect(@parser.parse("1 111", "JOD")).to eq(Money.new(1_111, 'JOD'))
+    end
+
+    it "parses decimals correctly" do
+      expect(@parser.parse("1.111", "JOD")).to eq(Money.new(1.111, 'JOD'))
+      expect(@parser.parse("1,11", "JOD")).to eq(Money.new(1.11, 'JOD'))
+    end
+  end
+
+  describe "no decimal currency" do
+    it "parses thousands correctly" do
+      expect(@parser.parse("1,111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+      expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+      expect(@parser.parse("1 111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+    end
+
+    it "parses decimals correctly" do
+      expect(@parser.parse("1,11", "JPY")).to eq(Money.new(1, 'JPY'))
+      expect(@parser.parse("1.11", "JPY")).to eq(Money.new(1, 'JPY'))
+    end
+  end
+
+  describe "two decimal currency" do
+    it "parses thousands correctly" do
+      expect(@parser.parse("1,111", "USD")).to eq(Money.new(1_111, 'USD'))
+      expect(@parser.parse("1.111", "USD")).to eq(Money.new(1_111, 'USD'))
+      expect(@parser.parse("1 111", "USD")).to eq(Money.new(1_111, 'USD'))
+    end
+
+    it "parses decimals correctly" do
+      expect(@parser.parse("1,11", "USD")).to eq(Money.new(1.11, 'USD'))
+      expect(@parser.parse("1.11", "USD")).to eq(Money.new(1.11, 'USD'))
+    end
+  end
+
   describe "parsing of decimal cents amounts from 0 to 10" do
     it "parses 50.0" do
       expect(@parser.parse("50.0")).to eq(Money.new(50.00))


### PR DESCRIPTION
# Why 
We want to avoid parsing using the currency information as much as possible (since locale is better). In cases where we're not faced with a 3 digit currency, it's false to assume that the thousand delimiter is that of the currency. 

# What 
This PR will make sure we're dealing with a 3 digit currency when checking if the last mark matches the currency's decimal mark.