### PR TITLE
legacy support for invalid decimal mark only for consistent numbers

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -141,7 +141,8 @@ class MoneyParser
       return true
     end
 
-    if currency.minor_units < 3 && digits.last.size == 3
+    # legacy support for 1.000 USD
+    if digits.last.size == 3 && digits.first.size <= 3 && currency.minor_units < 3
       return false
     end
 

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -229,11 +229,13 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("1,111", "JOD")).to eq(Money.new(1_111, 'JOD'))
       expect(@parser.parse("1.111.111", "JOD")).to eq(Money.new(1_111_111, 'JOD'))
       expect(@parser.parse("1 111", "JOD")).to eq(Money.new(1_111, 'JOD'))
+      expect(@parser.parse("1111,111", "JOD")).to eq(Money.new(1_111_111, 'JOD'))
     end
 
     it "parses decimals correctly" do
       expect(@parser.parse("1.111", "JOD")).to eq(Money.new(1.111, 'JOD'))
-      expect(@parser.parse("1,11", "JOD")).to eq(Money.new(1.11, 'JOD'))
+      expect(@parser.parse("1,11", "JOD")).to eq(Money.new(1.110, 'JOD'))
+      expect(@parser.parse("1111.111", "JOD")).to eq(Money.new(1_111.111, 'JOD'))
     end
   end
 
@@ -242,11 +244,13 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("1,111", "JPY")).to eq(Money.new(1_111, 'JPY'))
       expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1_111, 'JPY'))
       expect(@parser.parse("1 111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+      expect(@parser.parse("1111,111", "JPY")).to eq(Money.new(1_111_111, 'JPY'))
     end
 
     it "parses decimals correctly" do
       expect(@parser.parse("1,11", "JPY")).to eq(Money.new(1, 'JPY'))
       expect(@parser.parse("1.11", "JPY")).to eq(Money.new(1, 'JPY'))
+      expect(@parser.parse("1111.111", "JPY")).to eq(Money.new(1111, 'JPY'))
     end
   end
 
@@ -255,11 +259,13 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("1,111", "USD")).to eq(Money.new(1_111, 'USD'))
       expect(@parser.parse("1.111", "USD")).to eq(Money.new(1_111, 'USD'))
       expect(@parser.parse("1 111", "USD")).to eq(Money.new(1_111, 'USD'))
+      expect(@parser.parse("1111,111", "USD")).to eq(Money.new(1_111_111, 'USD'))
     end
 
     it "parses decimals correctly" do
       expect(@parser.parse("1,11", "USD")).to eq(Money.new(1.11, 'USD'))
       expect(@parser.parse("1.11", "USD")).to eq(Money.new(1.11, 'USD'))
+      expect(@parser.parse("1111.111", "USD")).to eq(Money.new(1111.11, 'USD'))
     end
   end
 


### PR DESCRIPTION
# Why
We want to support legacy usage of invalid decimal mark for a currency (example someone writing `1.000 USD` for one thousand. In order to limit the scope of this legacy support, we should only apply this to well formatted numbers

# What
look for numbers with a single mark for which there are 3 or less numbers before the mark. More than 3 numbers will fallback to the currency's decimal mark (example `1234.123 USD` will be using the regular parsing which will equate to `1234.12 USD`)