### PR TITLE
inherit money columns options

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -122,6 +122,11 @@ module MoneyColumn
           super(value)
         end
       end
+
+      def inherited(subclass)
+        subclass.instance_variable_set('@money_column_options', money_column_options.dup) if money_column_options
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
# Why
Fix the bug introduced by https://github.com/Shopify/money/commit/6cece85b7ab087e0b4bfc885099c2e4cee5062dd when money_columns are used with class inheritance where the child class did not see the parent's money_columns options.

# What
- share money_column options between parent and child class
- 🤦‍♂️ add missing tests for inheritance... 