### PR TITLE
deprecation warning when no currency is provided

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -10,9 +10,13 @@ class Money
   class << self
     attr_accessor :parser, :default_currency
 
-    def new(value = 0, currency = nil)
-      value = Helpers.value_to_decimal(value)
-      currency = Helpers.value_to_currency(currency)
+    def new(raw_value = 0, raw_currency = nil)
+      value = Helpers.value_to_decimal(raw_value)
+      currency = Helpers.value_to_currency(raw_currency)
+
+      Money.deprecate(
+        "using Money.new(amount) without a currency is deprecated and will raise an ArgumentError in the next major release"
+      ) if raw_currency.nil? && currency == NULL_CURRENCY
 
       if value.zero?
         @@zero_money ||= {}

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 
 RSpec.shared_examples_for "an object supporting to_money" do
   it "supports to_money" do
+    expect(@value.to_money('CAD')).to eq(Money.new(@value, 'CAD'))
+  end
+
+  it "supports to_money without a currency [DEPRECATED]" do
+    expect(Money).to receive(:deprecate).once
     expect(@value.to_money).to eq(@money)
-    expect(@value.to_money('CAD').currency).to eq(Money::Currency.find!('CAD'))
   end
 end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Money::Helpers do
 
   describe 'value_to_decimal' do
     let (:amount) { BigDecimal('1.23') }
-    let (:money) { Money.new(amount) }
+    let (:money) { Money.new(amount, 'USD') }
 
     it 'returns the value of a money object' do
       expect(subject.value_to_decimal(money)).to eq(amount)

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -169,12 +169,17 @@ RSpec.describe MoneyParser do
       expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
     end
 
+    it "parses without a currency [DEPRECATED]" do
+      expect(Money).to receive(:deprecate).once
+      expect(@parser.parse("100,00")).to eq(Money.new(100.00))
+    end
+
     it "parses negative hundreds amount" do
-      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
+      expect(@parser.parse("-100,00", 'CAD')).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses positive hundreds amount" do
-      expect(@parser.parse("410,00")).to eq(Money.new(410.00))
+      expect(@parser.parse("410,00", 'CAD')).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe "Money" do
   end
 
   describe "with amount of $1 with created with 3 decimal places" do
-    let (:money) { Money.new(1.125) }
+    let (:money) { Money.new(1.125, 'USD') }
 
     it "rounds 3rd decimal place" do
       expect(money.value).to eq(BigDecimal("1.13"))


### PR DESCRIPTION
WIP

# Why
We should be forced to add a currency whenever creating a money object. 

# What
This PR adds a deprecation warning to notify users that in the next release they will have an exception if they do not provide a currency.

