### PR TITLE
to_money assign currency when none

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -183,7 +183,16 @@ class Money
     [ReverseOperationProxy.new(other), self]
   end
 
-  def to_money(_currency = nil)
+  def to_money(curr = nil)
+    if !curr.nil? && no_currency?
+      return Money.new(value, curr)
+    end
+
+    curr = Helpers.value_to_currency(curr)
+    unless currency.compatible?(curr)
+      Money.deprecate("mathematical operation not permitted for Money objects with different currencies #{curr} and #{currency}.")
+    end
+
     self
   end
 
@@ -388,9 +397,6 @@ class Money
     raise TypeError, "#{money_or_numeric.class.name} can't be coerced into Money" unless money_or_numeric.respond_to?(:to_money)
     other = money_or_numeric.to_money(currency)
 
-    unless currency.compatible?(other.currency)
-      Money.deprecate("mathematical operation not permitted for Money objects with different currencies #{other.currency} and #{currency}.")
-    end
     yield(other)
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe "Money" do
     expect(money.to_money).to eq(money)
   end
 
+  it "#to_money uses the provided currency when it doesn't already have one" do
+    expect(Money.new(1).to_money('CAD')).to eq(Money.new(1, 'CAD'))
+  end
+
+  it "#to_money doesn't overwrite the money object's currency" do
+    expect(Money).to receive(:deprecate).once
+    expect(Money.new(1, 'USD').to_money('CAD')).to eq(Money.new(1, 'USD'))
+  end
+
   it "defaults to 0 when constructed with no arguments" do
     expect(Money.new).to eq(Money.new(0))
   end


### PR DESCRIPTION
# Why
Money with no currency should always take the provided currency when one is available.


# What 
```ruby
money = Money.new(1)
money.to_money('USD')
money.currency.to_s == 'USD' #=> true
```