### PR TITLE
Allow Money.zero to specify a currency for strictness

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -23,8 +23,8 @@ class Money
     end
     alias_method :from_amount, :new
 
-    def zero
-      new(0, NULL_CURRENCY)
+    def zero(currency = NULL_CURRENCY)
+      new(0, currency)
     end
     alias_method :empty, :zero
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe "Money" do
     expect(Money.zero).to eq(Money.new(0))
   end
 
+  it ".zero accepts an optional currency" do
+    expect(Money.zero('USD')).to eq(Money.new(0, 'USD'))
+  end
+
   it "returns itself with to_money" do
     expect(money.to_money).to eq(money)
   end


### PR DESCRIPTION
Sometimes we want a specific currency around our zero money instead of a null currency