### PR TITLE
Revert "Allow Money.zero to specify a currency for strictness"

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -23,8 +23,8 @@ class Money
     end
     alias_method :from_amount, :new
 
-    def zero(currency = NULL_CURRENCY)
-      new(0, currency)
+    def zero
+      new(0, NULL_CURRENCY)
     end
     alias_method :empty, :zero
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -34,10 +34,6 @@ RSpec.describe "Money" do
     expect(Money.zero).to eq(Money.new(0))
   end
 
-  it ".zero accepts an optional currency" do
-    expect(Money.zero('USD')).to eq(Money.new(0, 'USD'))
-  end
-
   it "returns itself with to_money" do
     expect(money.to_money).to eq(money)
   end


### PR DESCRIPTION
Reverts Shopify/money#156

It was not really documented, if you go searching for it you might've found https://github.com/Shopify/money/pull/105#issuecomment-329260394 and there's definitely been some discussion on Slack that's now archived, so I guess that's my fault for not writing it up.

But I've understood `Money.zero`'s intention was to return a polymorphic zero, i.e. always a null currency, even with the end goal of removing the implicit default currency (see https://github.com/Shopify/money/pull/154). 

We stumbled across this concept in the RubyMoney repo where [this paper](http://stephane.ducasse.free.fr/Teaching/CoursAnnecy/0506-M1-COO/aconcagua-p292-wilkinson.pdf) (paragraph 3.7) was referenced. It's useful as an initial value for `sum` if you don't care about the currency when the amount is zero, which IIRC fitted a couple of cases we saw in core at the time.

Besides that, `Money.new(0, 'USD')` was always an option. I'm not sure what value `Money.zero('USD')` brings to achieve the same thing?