### PR TITLE
Refer to correct column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Shopify/money.svg?branch=master)](https://travis-ci.org/Shopify/money) [![codecov](https://codecov.io/gh/Shopify/money/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/money)
 
 
-money_column expects a decimal 8,3 database field.
+money_column expects a DECIMAL(20,3) database field.
 
 ### Features
 


### PR DESCRIPTION
`money_column` expects a DECIMAL(20,3) column is the best practice. Updating info at top of readme. Also matches example.