### PR TITLE
to_money handle empty string efficiently

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -13,6 +13,6 @@ end
 #   '100.37'.to_money => #<Money @cents=10037>
 class String
   def to_money(currency = nil)
-    empty? ? Money.empty : Money.parse(self, currency)
+    Money.parse(self, currency)
   end
 end

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -5,7 +5,7 @@ class Money
   module Helpers
     module_function
 
-    NUMERIC_REGEX = /\A\s*[\+\-]?\d*(\.\d+)?\s*\z/
+    NUMERIC_REGEX = /\A\s*[\+\-]?(\d+|\d*\.\d+)\s*\z/
     DECIMAL_ZERO = BigDecimal(0).freeze
     MAX_DECIMAL = 21
 

--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -74,7 +74,7 @@ class MoneyParser
       return input
     end
 
-    if input.empty?
+    if input.strip.empty?
       return '0'
     end
 

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Integer do
   end
 
   it_should_behave_like "an object supporting to_money"
+
+  it "parses 0 to Money.zero" do
+    expect(0.to_money).to eq(Money.zero)
+  end
 end
 
 RSpec.describe Float do
@@ -23,6 +27,10 @@ RSpec.describe Float do
   end
 
   it_should_behave_like "an object supporting to_money"
+
+  it "parses 0.0 to Money.zero" do
+    expect(0.0.to_money).to eq(Money.zero)
+  end
 end
 
 RSpec.describe String do
@@ -32,6 +40,11 @@ RSpec.describe String do
   end
 
   it_should_behave_like "an object supporting to_money"
+
+  it "parses an empty string to Money.zero" do
+    expect(''.to_money).to eq(Money.zero)
+    expect(' '.to_money).to eq(Money.zero)
+  end
 end
 
 RSpec.describe BigDecimal do
@@ -41,4 +54,8 @@ RSpec.describe BigDecimal do
   end
 
   it_should_behave_like "an object supporting to_money"
+
+  it "parses a zero BigDecimal to Money.zero" do
+    expect(BigDecimal.new("-0.000").to_money).to eq(Money.zero)
+  end
 end


### PR DESCRIPTION
# What
Efficiently handle `"  "` empty string. (note spaces `"  ".empty? #=> false`)

# Why
- simplify `to_money` which will make further PRs simpler
- speed boost for multiple empty char strings
- use of `strip.empty?`

```
[10] pry(main)> Benchmark.ips do |x|
[10] pry(main)*   x.report("strip") { "  ".strip.empty? }
[10] pry(main)*   x.report("regex") { "  " !~ /\S/ }
[10] pry(main)*   x.compare!
[10] pry(main)* end
Warming up --------------------------------------
               strip   197.503k i/100ms
               regex   105.010k i/100ms
Calculating -------------------------------------
               strip      4.136M (± 3.8%) i/s -     20.738M in   5.021436s
               regex      1.670M (± 4.7%) i/s -      8.401M in   5.044041s

Comparison:
               strip:  4136073.3 i/s
               regex:  1669595.0 i/s - 2.48x  slower
```