### PR TITLE
parser delegate non string to money

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -63,13 +63,17 @@ class MoneyParser
 
   def parse(input, currency = nil, strict: false)
     currency = Money::Helpers.value_to_currency(currency)
-    amount = extract_money(input.to_s, currency, strict)
+    amount = extract_amount_from_string(input, currency, strict)
     Money.new(amount, currency)
   end
 
   private
 
-  def extract_money(input, currency, strict)
+  def extract_amount_from_string(input, currency, strict)
+    unless input.is_a?(String)
+      return input
+    end
+
     if input.empty?
       return '0'
     end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -333,6 +333,10 @@ RSpec.describe MoneyParser do
     it "parses 1.32" do
       expect(@parser.parse(1.32)).to eq(Money.new(1.32))
     end
+
+    it "parses 1.234" do
+      expect(@parser.parse(1.234)).to eq(Money.new(1.234))
+    end
   end
 
   describe "parsing with thousands separators" do


### PR DESCRIPTION
# Why
Avoid parsing non string inputs
For now we want to avoid a scenario like 8% tax 
```ruby
Money.parse(1.66 * 0.8) #=> Money.new(1328), should be Money.new(1.33)
```

# What

- delegate anything passed to `Money.parse` that is not a string to `Money.new`

