### PR TITLE
JSON serialize to a string in both ActiveSupport and JSON

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -215,7 +215,7 @@ class Money
   end
 
   def to_json(options = {})
-    to_s
+    "\"#{to_s}\""
   end
 
   def as_json(*args)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe "Money" do
     expect(money.as_json).to eq("1.00")
   end
 
+  it "has a consistent json encoding" do
+    expect(ActiveSupport::JSON.encode(money)).to eq(::JSON.dump(money))
+  end
+
   it "is constructable with a BigDecimal" do
     expect(Money.new(BigDecimal("1.23"))).to eq(Money.new(1.23))
   end
@@ -283,7 +287,7 @@ RSpec.describe "Money" do
   end
 
   it "returns cents in to_json" do
-    expect(Money.new(1.00).to_json).to eq("1.00")
+    expect(Money.new(1.00).to_json).to eq('"1.00"')
   end
 
   it "supports absolute value" do


### PR DESCRIPTION
Before this commit, ActiveSupport and the JSON gem serializes
Money objects to different things due to `as_json` and `to_json`
having different interfaces.

This patch makes it so that under both libraries, Money consistently
serializes to a string in JSON.

I found this issue while trying to get core to run on Ruby 2.5.1. I needed to upgrade Oj and the new Oj behaves exactly like the json gem (under our config) while the Oj we currently use behave like ActiveSupport. So this is for getting the current behaviour in the updated Oj. ~I can work around it in core by telling Oj to behave like ActiveSupport again, but I thought I open something here.~

Edit: I actually might need this merged for the update.

Related to #76