### PR TITLE
Enable money_column to write currency to DB when default currency is nil

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -48,19 +48,14 @@ module MoneyColumn
         return self[column] = nil
       end
 
-      currency_raw_source = begin
-        options[:currency] || send(options[:currency_column]) || money.currency
-      rescue
-        nil
-      end
-
-      currency_source = Money::Helpers.value_to_currency(currency_raw_source)
+      currency_raw_source = options[:currency] || (send(options[:currency_column]) rescue nil)
 
       if !money.is_a?(Money)
-        return self[column] = Money.new(money, currency_source).value
+        return self[column] = Money.new(money, currency_raw_source).value
       end
 
-      if currency_raw_source && !currency_source.compatible?(money.currency)
+      currency_source = currency_raw_source ? Money::Helpers.value_to_currency(currency_raw_source) : Money::NULL_CURRENCY
+      unless currency_source.compatible?(money.currency)
         Money.deprecate("[money_column] currency mismatch between #{currency_source} and #{money.currency}.")
       end
 

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -48,7 +48,12 @@ module MoneyColumn
         return self[column] = nil
       end
 
-      currency_raw_source = options[:currency] || (send(options[:currency_column]) rescue nil)
+      currency_raw_source = begin
+        options[:currency] || send(options[:currency_column]) || money.currency
+      rescue
+        nil
+      end
+
       currency_source = Money::Helpers.value_to_currency(currency_raw_source)
 
       if !money.is_a?(Money)

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -367,4 +367,28 @@ RSpec.describe 'MoneyColumn' do
       expect(MoneyClassInheritance2.instance_variable_get(:@money_column_options).keys).to_not include('prix')
     end
   end
+
+  describe 'default_currency = nil' do
+    around do |example|
+      default_currency = Money.default_currency
+      Money.default_currency = nil
+      example.run
+      Money.default_currency = default_currency
+    end
+
+    it 'writes currency from input value to the db' do
+      record.update(currency: nil)
+      record.update(price: Money.new(7, 'GBP'))
+      record.reload
+      expect(record.price.value).to eq(7)
+      expect(record.price.currency.to_s).to eq('GBP')
+    end
+
+    it 'raises missing currency error when input is not a money object' do
+      record.update(currency: nil)
+
+      expect { record.update(price: 3) }
+        .to raise_error(ArgumentError, 'missing currency')
+    end
+  end
 end


### PR DESCRIPTION
## What

When `Money`'s default currency is set to `nil`, `money_column`, more specifically `#write_money_attribute`, fails to write the currency provided by the input Money object to the database. Instead it raises `ArgumentError, 'missing currency'`. 

Line 51 is only checking for the currency from one of the following: 
- Money's default currency
- The column's hardcoded currency
- The currency already assigned to the record's corresponding currency column

https://github.com/Shopify/money/blob/df3204ea232a657414f1c5f421d206a50be9dac4/lib/money_column/active_record_hooks.rb#L41-L64

## How

Enable the raw currency source to fall back to the input money object's currency. 
First check the default currency, then the currency already in the column finally, check the input currency. 
Obviously we want to rescue from the input not being a Money object so always default to nil. 

Note: If a `Money.default_currency` is set, options['currency'] will return the default currency so we'll never evaluate the column or input. 

## Why

This enables applications that don't have a default currency set to still write currency to the database with `money_column`. 
