### PR TITLE
Fix deprecation callstack

### DIFF
--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -8,7 +8,7 @@ Money.class_eval do
   def self.deprecate(message)
     if ACTIVE_SUPPORT_DEFINED
       external_callstack = caller_locations.reject do |location|
-        location.to_s.include?('gems/money')
+        location.to_s.include?('gems/shopify-money')
       end
       active_support_deprecator.warn("[Shopify/Money] #{message}\n", external_callstack)
     else


### PR DESCRIPTION
The Gem has been renamed from money to shopify-money which make
external_callstack fail to reject internal callstack lines.