### PR TITLE
Enable CLA bot

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla


### PR DESCRIPTION
👋 We are enabling the Contributor License Agreement (CLA) bot for all Shopify open source repositories. The CLA bot automates signing of CLAs for all people who are not part of the Shopify organization. All people external to Shopify contributing code are required to sign a CLA. **Members of Shopify do not need to sign and the check will automatically pass.**

The check looks like this:

<img width="706" alt="screen shot 2018-10-18 at 10 33 46 pm" src="https://user-images.githubusercontent.com/344839/47199340-f3a92780-d325-11e8-980a-3311d001bf0b.png">

If it fails, the GitHub check will direct contributors to https://cla.shopify.com. Once they have signed and when the GitHub check is rerun, the check will pass.
