### PR TITLE
no deprecation updating non-read-only currency column

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -54,13 +54,16 @@ module MoneyColumn
         return self[column] = Money.new(money, currency_raw_source).value
       end
 
-      currency_source = currency_raw_source ? Money::Helpers.value_to_currency(currency_raw_source) : Money::NULL_CURRENCY
-      unless currency_source.compatible?(money.currency)
-        Money.deprecate("[money_column] currency mismatch between #{currency_source} and #{money.currency}.")
+      if options[:currency_read_only]
+        currency_source = Money::Helpers.value_to_currency(currency_raw_source)
+        if currency_raw_source && !money.currency.compatible?(currency_source)
+          Money.deprecate("[money_column] currency mismatch between #{currency_source} and #{money.currency}.")
+        end
+      else
+        self[options[:currency_column]] = money.currency.to_s unless money.no_currency?
       end
 
       self[column] = money.value
-      self[options[:currency_column]] = money.currency.to_s unless options[:currency_read_only] || money.no_currency?
     end
 
     module ClassMethods

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -139,9 +139,8 @@ RSpec.describe 'MoneyColumn' do
     expect(record.currency.to_s).to eq('EUR')
   end
 
-  it 'does overwrite a currency if changed but will show a deprecation notice' do
+  it 'does overwrite a currency' do
     expect(record.currency.to_s).to eq('EUR')
-    expect(Money).to receive(:deprecate).once
     record.update(price: Money.new(4, 'JPY'))
     expect(record.currency.to_s).to eq('JPY')
   end


### PR DESCRIPTION
# Why
When `currency_read_only` is false or not set, we want to update the currency with that of the money column associated. Since it's the expected behaviour, there should not be a deprecation warning.

# What 
Skip the deprecation warning when `currency_read_only` is false or not set