### PR TITLE
Fix cache when using update_columns

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -25,6 +25,11 @@ module MoneyColumn
       super
     end
 
+    def write_attribute_without_type_cast(attr_name, _value, *args)
+      @money_column_cache[attr_name.to_s] = nil
+      super
+    end
+
     def read_money_attribute(column)
       column = column.to_s
       options = self.class.money_column_options[column]

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -83,7 +83,12 @@ RSpec.describe 'MoneyColumn' do
   end
 
   it 'writes the currency to the db using update_column' do
-    record.update_columns(price: Money.new(4, 'JPY'), devise: 'ok')
+    record.price
+    record.currency
+    record.devise
+
+    record.update_columns(price: 4, currency: 'JPY', devise: 'ok')
+
     expect(record.devise).to eq('ok')
     expect(record.price.value).to eq(4)
     expect(record.price.currency.to_s).to eq('JPY')

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -74,10 +74,17 @@ RSpec.describe 'MoneyColumn' do
     expect(record.price).to eq(Money.new(1.23, 'EUR'))
   end
 
-  it 'writes the currency to the db' do
+  it 'writes the currency to the db using update' do
     record.update(currency: nil)
     record.update(price: Money.new(4, 'JPY'))
     record.reload
+    expect(record.price.value).to eq(4)
+    expect(record.price.currency.to_s).to eq('JPY')
+  end
+
+  it 'writes the currency to the db using update_column' do
+    record.update_columns(price: Money.new(4, 'JPY'), devise: 'ok')
+    expect(record.devise).to eq('ok')
     expect(record.price.value).to eq(4)
     expect(record.price.currency.to_s).to eq('JPY')
   end


### PR DESCRIPTION
When a money column is updated with `update_columns` or `update_column` it will bypass the `write_money_attribute` and write directly to the db and this will make it only save the value and not the currency

workarounds
`.update_attribute(price: money)`
or
call `.reload` after updating the columns