### PR TITLE
Fix performance issue with the split method.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -346,13 +346,8 @@ class Money
     high = Money.from_subunits(low.subunits + 1, currency)
 
     remainder = subunits % num
-    result = []
 
-    num.times do |index|
-      result[index] = index < remainder ? high : low
-    end
-
-    return result
+    return Array.new(remainder, high) + Array.new(num - remainder, low)
   end
 
   # Clamps the value to be within the specified minimum and maximum. Returns


### PR DESCRIPTION
Fix: https://github.com/Shopify/shopify/issues/180876

@itarato Identified a performance issue with the way we distribute penny remainders when splitting a Money object.

Here is the results and the benchmark I've run to determine which implementation to use:
```
       user     system      total        real
original 14.440000   0.230000  14.670000 ( 14.698791)
new(num, low)  2.730000   0.200000   2.930000 (  2.962738)
new(remainder, high) + new(num - remainder, low)  0.660000   0.480000   1.140000 (  1.142063)
```

```
require 'benchmark'

n = 50_000
num = 5_000
remainder = 1_000
high = 10
low = 9

Benchmark.bm do |benchmark|
  benchmark.report("original") do
    n.times do
      result = []
      num.times do |index|
        result[index] = index < remainder ? high : low
      end
    end
  end

  benchmark.report("new(num, low)") do
    n.times do
      result = Array.new(num, low)
      remainder.times do |index|
        result[index] = high
      end
    end
  end

  benchmark.report("new(remainder, high) + new(num - remainder, low)") do
    n.times do
      result = Array.new(remainder, high) + Array.new(num - remainder, low)
    end
  end
end
```