### PR TITLE
Add new method for calulating splits without needing to return an array of splits.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -340,14 +340,32 @@ class Money
   # @example
   #   Money.new(100, "USD").split(3) #=> [Money.new(34), Money.new(33), Money.new(33)]
   def split(num)
+    calculate_splits(num).sum { |value, count| Array.new(count, value) }
+  end
+
+  # Calculate the splits evenly without losing pennies.
+  # Returns the number of high and low splits and the value of the high and low splits.
+  # Where high represents the Money value with the extra penny
+  # and low a Money without the extra penny.
+  #
+  # @param [2] number of parties.
+  #
+  # @return [Hash<Money, Integer>]
+  #
+  # @example
+  #   Money.new(100, "USD").calculate_splits(3) #=> {Money.new(34) => 1, Money.new(33) => 2}
+  def calculate_splits(num)
     raise ArgumentError, "need at least one party" if num < 1
     subunits = self.subunits
     low = Money.from_subunits(subunits / num, currency)
     high = Money.from_subunits(low.subunits + 1, currency)
 
-    remainder = subunits % num
+    num_high = subunits % num
 
-    return Array.new(remainder, high) + Array.new(num - remainder, low)
+    {}.tap do |result|
+      result[high] = num_high if num_high > 0
+      result[low] = num - num_high
+    end
   end
 
   # Clamps the value to be within the specified minimum and maximum. Returns

--- a/money.gemspec
+++ b/money.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rails", "~> 5.0")
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_development_dependency("database_cleaner", "~> 1.6")
-  s.add_development_dependency("sqlite3", "~> 1.3")
+  s.add_development_dependency("sqlite3", "~> 1.3.6")
   s.add_development_dependency("bigdecimal", "~> 1.3.2")
 
   s.files = `git ls-files`.split($/)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -618,6 +618,25 @@ RSpec.describe "Money" do
     end
   end
 
+  describe "calculate_splits" do
+    specify "#calculate_splits gives 1 cent to both people if we start with 2" do
+      actual = Money.new(0.02, 'CAD').calculate_splits(2)
+
+      expect(actual).to eq({
+        Money.new(0.01, 'CAD') => 2,
+      })
+    end
+
+    specify "#calculate_splits gives an extra penny to one" do
+      actual = Money.new(0.04, 'CAD').calculate_splits(3)
+
+      expect(actual).to eq({
+        Money.new(0.02, 'CAD') => 1,
+        Money.new(0.01, 'CAD') => 2,
+      })
+    end
+  end
+
   describe "fraction" do
     specify "#fraction needs a positive rate" do
       expect {Money.new(1).fraction(-0.5)}.to raise_error(ArgumentError)


### PR DESCRIPTION
Returning an array of Money might not always be the best solution when all you care about it to mutate and transform the returned Array. I'm proposing we add a new method that returns the splits information so we can do arithmetics on the information without requiring a new Array. Sometimes returning an array works, but some other times, it causes a lot of stress on the RAM with a very high num parameter.