### PR TITLE
explicit bigdecimal version

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@
 ---
 name: money
 up:
-- ruby: 2.3.3
+- ruby: 2.5.3
 - bundler
 commands:
   test: bundle exec rspec

--- a/money.gemspec
+++ b/money.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 3.2")
   s.add_development_dependency("database_cleaner", "~> 1.6")
   s.add_development_dependency("sqlite3", "~> 1.3")
-  s.add_development_dependency("bigdecimal", ">= 1.3.2")
+  s.add_development_dependency("bigdecimal", "~> 1.3.2")
 
   s.files = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Fix test failure

```
1) Money::Helpers value_to_decimal returns the bigdecimal representation of numbers while they are deprecated
     Failure/Error: expect(subject.value_to_decimal('1.23abc')).to eq(amount)
     
       expected: 0.123e1
            got: 0.0
     
       (compared using ==)
     # ./spec/helpers_spec.rb:54:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:57:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.5.0/gems/database_cleaner-1.7.0/lib/database_cleaner/generic/base.rb:16:in `cleaning'
     # ./vendor/bundle/ruby/2.5.0/gems/database_cleaner-1.7.0/lib/database_cleaner/base.rb:100:in `cleaning'
     # ./vendor/bundle/ruby/2.5.0/gems/database_cleaner-1.7.0/lib/database_cleaner/configuration.rb:86:in `block (2 levels) in cleaning'
     # ./vendor/bundle/ruby/2.5.0/gems/database_cleaner-1.7.0/lib/database_cleaner/configuration.rb:87:in `cleaning'
     # ./spec/spec_helper.rb:56:in `block (2 levels) in <top (required)>'
```
version needs to be updated in core first