### PR TITLE
Money.new to raise on invalid number string

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -56,16 +56,11 @@ class Money
     end
 
     def string_to_decimal(num)
-      if num =~ NUMERIC_REGEX
-        return BigDecimal(num)
+      unless num =~ NUMERIC_REGEX
+        raise ArgumentError, "`#{num}` is not a number, consider using Money.parse('#{num}', currency)"
       end
 
-      Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
-      begin
-        BigDecimal(num)
-      rescue ArgumentError
-        DECIMAL_ZERO
-      end
+      BigDecimal(num)
     end
   end
 end

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = "0.11.8"
+  VERSION = "0.12.0"
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -44,15 +44,9 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_decimal(' -1.23 ')).to eq(-amount)
     end
 
-    it 'invalid string returns zero' do
-      expect(Money).to receive(:deprecate).once
-      expect(subject.value_to_decimal('invalid')).to eq(0)
-    end
-
-    it 'returns the bigdecimal representation of numbers while they are deprecated' do
-      expect(Money).to receive(:deprecate).exactly(2).times
-      expect(subject.value_to_decimal('1.23abc')).to eq(amount)
-      expect(subject.value_to_decimal("1.23\n23")).to eq(amount)
+    it 'raises on invalid number strings' do
+      expect { subject.value_to_decimal('1.23abc') }.to raise_error(ArgumentError)
+      expect { subject.value_to_decimal("1.23\n23") }.to raise_error(ArgumentError)
     end
 
     it 'raises on invalid object' do

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe 'MoneyColumn' do
   describe 'garbage amount' do
     let(:amount) { 'foo' }
 
-    it 'raises a deprecation warning' do
-      expect { subject }.to raise_error(ActiveSupport::DeprecationException)
+    it 'raises an argument error' do
+      expect { subject }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe "Money" do
   end
 
   it "defaults to 0 when constructed with an invalid string" do
-    expect(Money).to receive(:deprecate).once
-    expect(Money.new('invalid')).to eq(Money.new(0.00))
+    expect{ Money.new('invalid') }.to raise_error(ArgumentError)
   end
 
   it "to_s correctly displays the right number of decimal places" do


### PR DESCRIPTION
# Why

`Money.new('invalid')` has been deprecated for 1 year, the time has come to raise on invalid number strings.
This behaviour leads to many unexpected bugs when dealing with localized strings, for example `Money.new('1,00') == Money.new(0)`

re https://github.com/Shopify/money/issues/69

# What
- raise instead of the deprecation
- version bump to 0.12
- hint to consider `Money.parse` instead of `Money.new` in the error message