### PR TITLE
Add method sum_splits

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -618,22 +618,17 @@ RSpec.describe "Money" do
     end
   end
 
-  describe "calculate_splits" do
-    specify "#calculate_splits gives 1 cent to both people if we start with 2" do
-      actual = Money.new(0.02, 'CAD').calculate_splits(2)
+  describe "sum_splits" do
+    specify "returns self if no block given" do
+      actual = Money.new(0.02, 'CAD').sum_splits(2)
 
-      expect(actual).to eq({
-        Money.new(0.01, 'CAD') => 2,
-      })
+      expect(actual).to eq(Money.new(0.02, 'CAD'))
     end
 
-    specify "#calculate_splits gives an extra penny to one" do
-      actual = Money.new(0.04, 'CAD').calculate_splits(3)
+    specify "returns a transformed Money based on given block" do
+      actual = Money.new(100, 'USD').sum_splits(3) { |m| m.allocate([0.9, 0.1]).last}
 
-      expect(actual).to eq({
-        Money.new(0.02, 'CAD') => 1,
-        Money.new(0.01, 'CAD') => 2,
-      })
+      expect(actual).to eq(Money.new(9.99, 'USD'))
     end
   end
 


### PR DESCRIPTION
Move `calculate_splits` to a private method and add method `sum_splits`.

While less flexible, this new method is clearer for the reader to figure out what it is doing. I've chosen this approach since it is similar to how `Enumerable#sum` works. This gives a familiar interface for any Ruby user.

cc @elsom25 @cpauderis 