### PR TITLE
DO NOT MERGE Tweak Money#<=> to be consistent with Money#==

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -115,16 +115,10 @@ class Money
 
   def <=>(other)
     return unless other.respond_to?(:to_money)
-    arithmetic(other) do |money|
-      value <=> money.value
-    end
-  end
 
-  # TODO: Remove once cross-currency mathematical operations are no longer allowed
-  def ==(other)
-    return false unless other.is_a?(Money)
-    return false unless currency.compatible?(other.currency)
-    super
+    arithmetic(other) do |money|
+      value <=> money.value if currency.compatible?(money.currency)
+    end
   end
   alias_method(:eql?, :==)
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -114,10 +114,19 @@ class Money
   end
 
   def <=>(other)
+    return unless other.respond_to?(:to_money)
     arithmetic(other) do |money|
       value <=> money.value
     end
   end
+
+  # TODO: Remove once cross-currency mathematical operations are no longer allowed
+  def ==(other)
+    return false unless other.is_a?(Money)
+    return false unless currency.compatible?(other.currency)
+    super
+  end
+  alias_method(:eql?, :==)
 
   def +(other)
     arithmetic(other) do |money|
@@ -144,16 +153,6 @@ class Money
 
   def inspect
     "#<#{self.class} value:#{self} currency:#{self.currency}>"
-  end
-
-  def ==(other)
-    eql?(other)
-  end
-
-  def eql?(other)
-    return false unless other.is_a?(Money)
-    return false unless currency.compatible?(other.currency)
-    value == other.value
   end
 
   class ReverseOperationProxy

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = "0.11.9"
+  VERSION = "0.12.0"
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 RSpec.describe "Money" do
 
-  let (:money) {Money.new(1)}
+  let (:money) { Money.new(1) }
   let (:amount_money) { Money.new(1.23, 'USD') }
   let (:non_fractional_money) { Money.new(1, 'JPY') }
   let (:zero_money) { Money.new(0) }
@@ -374,16 +374,8 @@ RSpec.describe "Money" do
       expect((0.5 <=> money)).to eq(-1)
     end
 
-    it "raises error if compared other is not compatible" do
-      expect{ Money.new(5.00) <=> nil }.to raise_error(TypeError)
-    end
-
-    it "have the same hash value as $1" do
-      expect(money.hash).to eq(Money.new(1.00).hash)
-    end
-
-    it "does not have the same hash value as $2" do
-      expect(money.hash).to eq(Money.new(1.00).hash)
+    it "<=> returns nil with non-coercible non-money objects" do
+      expect((money <=> nil)).to(eq(nil))
     end
 
     it "<=> can compare with and without currency" do
@@ -395,6 +387,14 @@ RSpec.describe "Money" do
       expect(Money).to receive(:deprecate).twice
       expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(-1)
       expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(1)
+    end
+
+    it "have the same hash value as $1" do
+      expect(money.hash).to eq(Money.new(1.00).hash)
+    end
+
+    it "does not have the same hash value as $2" do
+      expect(money.hash).to eq(Money.new(1.00).hash)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -180,12 +180,13 @@ RSpec.describe "Money" do
     expect(money).to eq(Money.new(1, 'CAD'))
   end
 
-  it "does not eql? with a non money object" do
-    expect(money).to_not eq(1)
+  it "does not eql? with a non-coercible non-money object" do
     expect(money).to_not eq(OpenStruct.new(value: 1))
+    expect(money).to_not eq(nil)
   end
 
   it "does not eql? when currency missmatch" do
+    expect(Money).to receive(:deprecate).once
     expect(money).to_not eq(Money.new(1, 'JPY'))
   end
 
@@ -383,10 +384,10 @@ RSpec.describe "Money" do
       expect(Money.new(2000, 'JPY') <=> Money.new(1000, Money::NULL_CURRENCY)).to eq(1)
     end
 
-    it "<=> issues deprecation warning when comparing incompatible currency" do
+    it "<=> returns nil when comparing incompatible currency" do
       expect(Money).to receive(:deprecate).twice
-      expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(-1)
-      expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(1)
+      expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(nil)
+      expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(nil)
     end
 
     it "have the same hash value as $1" do


### PR DESCRIPTION
Right now we have inconsistent responses around equality between `==` (and thus `#eql?`) and `<=>`. This can lead to surprising results.

For example:
```rb
[1] Money.new(2.0) == 2.0
=> false
[2] Money.new(2.0) <=> 2.0
=> 0
```

This PR makes it so that `==`, `eql?`, and `<=>` behave consistently. One side-effect of this however is that `<=>` will return `nil` in more cases (as to be consistent with the old behaviour of `==`), which is why there's a "major" version bump (as major as you can have with pre 1.0).