### PR TITLE
Make readme consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ generate methods for use with ActiveRecord:
 
 ```ruby
 create_table :orders do |t|
-  t.decimal :sub_total, precision: 20, scale: 3
-  t.decimal :tax, precision: 20, scale: 3
+  t.decimal :sub_total, precision: 21, scale: 3
+  t.decimal :tax, precision: 21, scale: 3
   t.string :currency, limit: 3
 end
 


### PR DESCRIPTION
At the top of the readme, it says:

> money_column expects a DECIMAL(21,3) database field.

But then the example migration uses `DECIMAL(20,3)`. This updates the example to match the actual expectation.