### PR TITLE
HUF has 2 minor units per ISO 4217

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -934,7 +934,7 @@
     "symbol": "Ft",
     "alternate_symbols": [],
     "subunit": "",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",


### PR DESCRIPTION
The Hungarian Forint poses an interesting challenge: it's subunit (fillér) is not in use anymore, but according to https://www.currency-iso.org/en/home/tables/table-a1.html the currency still has two minor units. Displaying it as such (e.g. like Euro) might be confusing for end-users though.

This gem represents uses decimal values for amounts. For interoperating with systems that use integer representations, for example [Stripe](https://stripe.com/docs/currencies#zero-decimal), having a shared understanding of how many minor units a currencies has is crucial. Otherwise, code like `Money.from_subunits(40_000, 'HUF')` would not equal 400 Forint as originally meant by the other party, but 100x more. The aforementioned currency-iso.org link is the authoritative source for this information and thus the only one to use for sane interoperability.

What people may or may not consider 'normal' as values to be displayed is best left to the view layer to be solved.