### PR TITLE
Update calculation in amounts_from_splits using Rational and Integer

### DIFF
--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe "Allocator" do
     specify "#allocate raise ArgumentError when invalid strategy is provided" do
       expect { new_allocator(0.03).allocate([0.5, 0.5], :bad_strategy_name) }.to raise_error(ArgumentError, "Invalid strategy. Valid options: :roundrobin, :roundrobin_reverse")
     end
+
+    specify "#allocate does not raise ArgumentError when invalid splits types are provided" do
+      moneys = new_allocator(0.03).allocate([0.5, 0.5], :roundrobin)
+      expect(moneys[0]).to eq(Money.new(0.02))
+      expect(moneys[1]).to eq(Money.new(0.01))
+    end
   end
 
   describe 'allocate_max_amounts' do
@@ -126,6 +132,12 @@ RSpec.describe "Allocator" do
       expect(
         new_allocator(3).allocate_max_amounts([Money.empty, Money.empty, Money.empty]),
       ).to eq([Money.empty, Money.empty, Money.empty])
+    end
+
+    specify "#allocate_max_amounts allocates the right amount without rounding error" do
+      expect(
+        new_allocator(24.2).allocate_max_amounts([Money.new(46), Money.new(46), Money.new(50), Money.new(50),Money.new(50)]),
+        ).to eq([Money.new(4.6), Money.new(4.6), Money.new(5), Money.new(5), Money.new(5)])
     end
   end
 


### PR DESCRIPTION
Update calculation in amounts_from_splits using Rational and Integer to avoid rounding error using BigDecimal.

This fix comes from an issue (https://github.com/Shopify/store/issues/1499) where the allocation of the leftover pennies went to the cheapest items meaning that the calculations felt off.
It caused another problem when trying to refund those product as they were off by a penny (or several if several were refunded).

For example a product with a price of 50$ and a 10% discount could be marked 4.99$ off instead of 5$.

This PR tries to address this by changing the types in the calculation of the max amounts as the rounding was wrong.
For example, in my case I had 5 items ( 2 * 46$ + 3 * 50$) with a discount of 10% off all those items.
The total discount is 24,20$ (or 2420 in subunits).
Calculation for the max amount for an item A at 46$ and item B at 50$ was as follow : 
`frac = (Helpers.value_to_decimal(subunits_to_split * ratio) / allocations).floor`
with 
```
subunits_to_split = 2420.0 {BigDecimal}
ratio = 23/121 (item A) {Rational}
ratio = 25/121 (item B) {Rational}
allocations = 1
subunits_to_split * ratio = 460.0000009 (item A) {BigDecimal}
subunits_to_split * ratio = 499.9999994 (item B) {BigDecimal}
```
Expected answer: 460 / 500

By doing the reverse calculation, it seems like the calcul is working as follow: 
`460.0000009 / 2420.0 = 0.190082645 (item A)`
`499.9999994 / 2420.0 = 0.20661157 (item B)`
When it's supposed to be: 
`ratio = 23/121 = 0.19008264462 (item A)`
`ratio = 23/121 = 0.2066115702 (item B)`

It seems like the ratio is rounded after the 9th decimal which leads to a rounding error afterward.
Case with item A works thanks to `.floor` but case with item B will be off by 1 penny because of `.floor`

I suggest to convert `subunits_to_split` from BigDecimal to Integer since the subunit in all currencies should be an `Integer`. 
That means that the calculation will give a `Rational` instead of a `BigDecimal` avoiding rounding issues.

## 🎩 instruction
Update the Gemfile in core with : `gem "shopify-money", path: "/Users/toto/money_fork"`

Then you can create discount with the same pattern as mentioned above (2 * 46$ items, 3 * 50$ items) and a discount of 10% off those 2 products.
Also make sure that the cheapest items are at the top of the list.
