### PR TITLE
2.7.0 compat: SimpleDelegator need to be required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
   only:
   - master
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 class Money
   class Allocator < SimpleDelegator
     def initialize(money)


### PR DESCRIPTION
It would work on older versions because it was used internally in rubygems:


```
$ ruby --version
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin19]
$ ruby -e 'p SimpleDelegator'
SimpleDelegator
$ ruby --disable-gems -e 'p SimpleDelegator'
Traceback (most recent call last):
-e:1:in `<main>': uninitialized constant SimpleDelegator (NameError)
```

Now on 2.7:

```
$ ruby --version
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
$ ruby -e 'p SimpleDelegator'
Traceback (most recent call last):
-e:1:in `<main>': uninitialized constant SimpleDelegator (NameError)
```