### PR TITLE
Bump Ruby requirement to 2.6 for faster string to BigDecimal path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
 rvm:
   - 2.7
   - 2.6
-  - 2.5
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
   - gem update --system

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@
 ---
 name: money
 up:
-- ruby: 2.5.3
+- ruby: 2.6.6
 - bundler
 commands:
   test: bundle exec rspec

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -5,7 +5,6 @@ class Money
   module Helpers
     module_function
 
-    NUMERIC_REGEX = /\A\s*[\+\-]?(\d+|\d*\.\d+)\s*\z/
     DECIMAL_ZERO = BigDecimal(0).freeze
     MAX_DECIMAL = 21
 
@@ -25,7 +24,11 @@ class Money
         when Rational
           BigDecimal(num, MAX_DECIMAL)
         when String
-          string_to_decimal(num)
+          decimal = BigDecimal(num, exception: false)
+          return decimal if decimal
+
+          Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
+          DECIMAL_ZERO
         else
           raise ArgumentError, "could not parse as decimal #{num.inspect}"
         end
@@ -52,19 +55,6 @@ class Money
         end
       else
         raise ArgumentError, "could not parse as currency #{currency.inspect}"
-      end
-    end
-
-    def string_to_decimal(num)
-      if num =~ NUMERIC_REGEX
-        return BigDecimal(num)
-      end
-
-      Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
-      begin
-        BigDecimal(num)
-      rescue ArgumentError
-        DECIMAL_ZERO
       end
     end
   end

--- a/money.gemspec
+++ b/money.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("database_cleaner", "~> 1.6")
   s.add_development_dependency("sqlite3", "~> 1.4.2")
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.files = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -50,12 +50,6 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_decimal('invalid')).to eq(0)
     end
 
-    it 'returns the bigdecimal representation of numbers while they are deprecated' do
-      expect(Money).to receive(:deprecate).exactly(2).times
-      expect(subject.value_to_decimal('0.00123e3')).to eq(amount)
-      expect(subject.value_to_decimal("0.123e1")).to eq(amount)
-    end
-
     it 'raises on invalid object' do
       expect { subject.value_to_decimal(OpenStruct.new(amount: 1)) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
Some informal testing of `Money.new("7", "CAD")` with benchmark-ips shows roughly a 40% improvement from ~250k to ~350k instructions per second.