### PR TITLE
Remove Money.zero and Money.empty

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -26,11 +26,6 @@ class Money
     end
     alias_method :from_amount, :new
 
-    def zero(currency = NULL_CURRENCY)
-      new(0, currency)
-    end
-    alias_method :empty, :zero
-
     def parse(*args, **kwargs)
       parser.parse(*args, **kwargs)
     end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -1,5 +1,36 @@
 # frozen_string_literal: true
 class Money
+  # A placeholder currency for instances where no actual currency is available,
+  # as defined by ISO4217. You should rarely, if ever, need to use this
+  # directly. It's here mostly for backwards compatibility and for that reason
+  # behaves like a dollar, which is how this gem worked before the introduction
+  # of currency.
+  #
+  # Here follows a list of preferred alternatives over using Money with
+  # NullCurrency:
+  #
+  # For comparisons where you don't know the currency beforehand, you can use
+  # Numeric predicate methods like #positive?/#negative?/#zero?/#nonzero?.
+  # Comparison operators with Numeric (==, !=, <=, =>, <, >) work as well.
+  #
+  # @example
+  #   Money.new(1, 'CAD').positive? #=> true
+  #   Money.new(2, 'CAD') >= 0      #=> true
+  #
+  # Money with NullCurrency has behaviour that may surprise you, such as
+  # database validations or GraphQL enum not allowing the string representation
+  # of NullCurrency. Prefer using Money.new(0, currency) where possible, as
+  # this sidesteps these issues and provides additional currency check
+  # safeties.
+  #
+  # Unlike other currencies, it is allowed to calculate a Money object with
+  # NullCurrency with another currency. The resulting Money object will have
+  # the other currency.
+  #
+  # @example
+  #   Money.new(0, Money::NULL_CURRENCY) + Money.new(5, 'CAD')
+  #   #=> #<Money value:5.00 currency:CAD>
+  #
   class NullCurrency
 
     attr_reader :iso_code, :iso_numeric, :name, :smallest_denomination, :subunit_symbol,
@@ -9,7 +40,7 @@ class Money
       @symbol                = '$'
       @disambiguate_symbol   = nil
       @subunit_symbol        = nil
-      @iso_code              = 'XXX' # Valid ISO4217
+      @iso_code              = 'XXX'
       @iso_numeric           = '999'
       @name                  = 'No Currency'
       @smallest_denomination = 1

--- a/lib/rubocop/cop/money/zero_money.rb
+++ b/lib/rubocop/cop/money/zero_money.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Money
+      class ZeroMoney < Cop
+        # `Money.zero` and it's alias `empty`, with or without currency
+        # argument is removed in favour of the more explicit Money.new
+        # syntax. Supplying it with a real currency is preferred for
+        # additional currency safety checks.
+        #
+        # If no currency was supplied, it defaults to
+        # Money::NULL_CURRENCY which was the default setting of
+        # Money.default_currency and should effectively be the same. The cop
+        # can be configured with a ReplacementCurrency in case that is more
+        # appropriate for your application.
+        #
+        # @example
+        #
+        #   # bad
+        #   Money.zero
+        #
+        #   # good when configured with `ReplacementCurrency: CAD`
+        #   Money.new(0, 'CAD')
+        #
+
+        MSG = 'Money.zero is removed, use `Money.new(0, %<currency>s)`.'
+
+        def_node_matcher :money_zero, <<~PATTERN
+          (send (const {nil? cbase} :Money) {:zero :empty} $...)
+        PATTERN
+
+        def on_send(node)
+          money_zero(node) do |currency_arg|
+            add_offense(node, message: format(MSG, currency: replacement_currency(currency_arg)))
+          end
+        end
+
+        def autocorrect(node)
+          receiver, _ = *node
+
+          lambda do |corrector|
+            money_zero(node) do |currency_arg|
+              replacement_currency = replacement_currency(currency_arg)
+
+              corrector.replace(
+                node.loc.expression,
+                "#{receiver.source}.new(0, #{replacement_currency})"
+              )
+            end
+          end
+        end
+
+        private
+
+        def replacement_currency(currency_arg)
+          return currency_arg.first.source unless currency_arg.empty?
+          return "'#{cop_config['ReplacementCurrency']}'" if cop_config['ReplacementCurrency']
+
+          'Money::NULL_CURRENCY'
+        end
+      end
+    end
+  end
+end

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Allocator" do
 
     specify "#allocate will convert rationals with high precision" do
       ratios = [Rational(1, 1), Rational(0)]
-      expect(new_allocator("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12"), Money.empty])
+      expect(new_allocator("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12"), Money.new(0, Money::NULL_CURRENCY)])
       ratios = [Rational(1, 6), Rational(5, 6)]
       expect(new_allocator("3.00").allocate(ratios)).to eq([Money.new("0.50"), Money.new("2.50")])
     end
@@ -131,8 +131,8 @@ RSpec.describe "Allocator" do
 
     specify "#allocate_max_amounts supports all-zero maxima" do
       expect(
-        new_allocator(3).allocate_max_amounts([Money.empty, Money.empty, Money.empty]),
-      ).to eq([Money.empty, Money.empty, Money.empty])
+        new_allocator(3).allocate_max_amounts([Money.new(0, Money::NULL_CURRENCY), Money.new(0, Money::NULL_CURRENCY), Money.new(0, Money::NULL_CURRENCY)]),
+      ).to eq([Money.new(0, Money::NULL_CURRENCY), Money.new(0, Money::NULL_CURRENCY), Money.new(0, Money::NULL_CURRENCY)])
     end
 
     specify "#allocate_max_amounts allocates the right amount without rounding error" do

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Integer do
   it_should_behave_like "an object supporting to_money"
 
   it "parses 0 to Money.zero" do
-    expect(0.to_money).to eq(Money.zero)
+    expect(0.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
@@ -30,7 +30,7 @@ RSpec.describe Float do
   it_should_behave_like "an object supporting to_money"
 
   it "parses 0.0 to Money.zero" do
-    expect(0.0.to_money).to eq(Money.zero)
+    expect(0.0.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
@@ -43,8 +43,8 @@ RSpec.describe String do
   it_should_behave_like "an object supporting to_money"
 
   it "parses an empty string to Money.zero" do
-    expect(''.to_money).to eq(Money.zero)
-    expect(' '.to_money).to eq(Money.zero)
+    expect(''.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(' '.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
@@ -57,6 +57,6 @@ RSpec.describe BigDecimal do
   it_should_behave_like "an object supporting to_money"
 
   it "parses a zero BigDecimal to Money.zero" do
-    expect(BigDecimal("-0.000").to_money).to eq(Money.zero)
+    expect(BigDecimal("-0.000").to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'MoneyColumn' do
 
   it 'does not overwrite a currency column with a default currency when saving zero' do
     expect(record.currency.to_s).to eq('EUR')
-    record.update(price: Money.zero)
+    record.update(price: Money.new(0, Money::NULL_CURRENCY))
     expect(record.currency.to_s).to eq('EUR')
   end
 

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe MoneyParser do
 
   describe "parsing of amounts with period decimal separator" do
     it "parses an empty string to $0" do
-      expect(@parser.parse("")).to eq(Money.zero)
+      expect(@parser.parse("")).to eq(Money.new(0, Money::NULL_CURRENCY))
     end
 
     it "parses an invalid string when not strict" do
       expect(Money).to receive(:deprecate).twice
-      expect(@parser.parse("no money")).to eq(Money.zero)
+      expect(@parser.parse("no money")).to eq(Money.new(0, Money::NULL_CURRENCY))
       expect(@parser.parse("1..")).to eq(Money.new(1))
     end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe "Money" do
   let (:non_fractional_money) { Money.new(1, 'JPY') }
   let (:zero_money) { Money.new(0) }
 
-  it "is contructable with empty class method" do
-    expect(Money.empty).to eq(Money.new)
-  end
-
   context "default currency not set" do
     before(:each) do
       @default_currency = Money.default_currency
@@ -28,15 +24,11 @@ RSpec.describe "Money" do
   end
 
   it ".zero has no currency" do
-    expect(Money.zero.currency).to be_a(Money::NullCurrency)
+    expect(Money.new(0, Money::NULL_CURRENCY).currency).to be_a(Money::NullCurrency)
   end
 
   it ".zero is a 0$ value" do
-    expect(Money.zero).to eq(Money.new(0))
-  end
-
-  it ".zero accepts an optional currency" do
-    expect(Money.zero('USD')).to eq(Money.new(0, 'USD'))
+    expect(Money.new(0, Money::NULL_CURRENCY)).to eq(Money.new(0))
   end
 
   it "returns itself with to_money" do

--- a/spec/rubocop/cop/money/missing_currency_spec.rb
+++ b/spec/rubocop/cop/money/missing_currency_spec.rb
@@ -8,11 +8,15 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
 
   let(:config) { RuboCop::Config.new }
 
-  describe '#on_send' do
-    it 'registers an offense for Money.new without a currency argument' do
+  context 'with default configuration' do
+    it 'registers an offense and corrects for Money.new without a currency argument' do
       expect_offense(<<~RUBY)
         Money.new(1)
         ^^^^^^^^^^^^ Money is missing currency argument
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(1, Money::NULL_CURRENCY)
       RUBY
     end
 
@@ -22,17 +26,25 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
       RUBY
     end
 
-    it 'registers an offense for Money.new without a currency argument' do
+    it 'registers an offense and corrects for Money.new without a currency argument' do
       expect_offense(<<~RUBY)
         Money.new
         ^^^^^^^^^ Money is missing currency argument
       RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(0, Money::NULL_CURRENCY)
+      RUBY
     end
 
-    it 'registers an offense for Money.from_amount without a currency argument' do
+    it 'registers an offense and corrects for Money.from_amount without a currency argument' do
       expect_offense(<<~RUBY)
         Money.from_amount(1)
         ^^^^^^^^^^^^^^^^^^^^ Money is missing currency argument
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.from_amount(1, Money::NULL_CURRENCY)
       RUBY
     end
 
@@ -42,10 +54,14 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
       RUBY
     end
 
-    it 'registers an offense for Money.from_cents without a currency argument' do
+    it 'registers an offense and corrects for Money.from_cents without a currency argument' do
       expect_offense(<<~RUBY)
         Money.from_cents(1)
         ^^^^^^^^^^^^^^^^^^^ Money is missing currency argument
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.from_cents(1, Money::NULL_CURRENCY)
       RUBY
     end
 
@@ -55,10 +71,14 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
       RUBY
     end
 
-    it 'registers an offense for to_money without a currency argument' do
+    it 'registers an offense and corrects for to_money without a currency argument' do
       expect_offense(<<~RUBY)
         '1'.to_money
         ^^^^^^^^^^^^ to_money is missing currency argument
+      RUBY
+
+      expect_correction(<<~RUBY)
+        '1'.to_money(Money::NULL_CURRENCY)
       RUBY
     end
 
@@ -68,15 +88,19 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
       RUBY
     end
 
-    it 'registers an offense for to_money block pass form' do
+    it 'registers an offense and corrects for to_money block pass form' do
       expect_offense(<<~RUBY)
         ['1'].map(&:to_money)
         ^^^^^^^^^^^^^^^^^^^^^ to_money is missing currency argument
       RUBY
+
+      expect_correction(<<~RUBY)
+        ['1'].map { |x| x.to_money(Money::NULL_CURRENCY) }
+      RUBY
     end
   end
 
-  describe '#autocorrect' do
+  context 'with ReplacementCurrency configuration' do
     let(:config) do
       RuboCop::Config.new(
         'Money/MissingCurrency' => {

--- a/spec/rubocop/cop/money/zero_money_spec.rb
+++ b/spec/rubocop/cop/money/zero_money_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../../../rubocop_helper'
+require 'rubocop/cop/money/zero_money'
+
+RSpec.describe RuboCop::Cop::Money::ZeroMoney do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context 'with default configuration' do
+    it 'registers an offense and corrects Money.zero without currency' do
+      expect_offense(<<~RUBY)
+        Money.zero
+        ^^^^^^^^^^ Money.zero is removed, use `Money.new(0, Money::NULL_CURRENCY)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(0, Money::NULL_CURRENCY)
+      RUBY
+    end
+
+    it 'registers an offense and corrects Money.zero with currency' do
+      expect_offense(<<~RUBY)
+        Money.zero('CAD')
+        ^^^^^^^^^^^^^^^^^ Money.zero is removed, use `Money.new(0, 'CAD')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(0, 'CAD')
+      RUBY
+    end
+
+    it 'does not register an offense when using Money.new with a currency' do
+      expect_no_offenses(<<~RUBY)
+        Money.new(0, 'CAD')
+      RUBY
+    end
+  end
+
+  context 'with ReplacementCurrency configuration' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Money/ZeroMoney' => {
+          'ReplacementCurrency' => 'CAD'
+        }
+      )
+    end
+
+    it 'registers an offense and corrects Money.zero without currency' do
+      expect_offense(<<~RUBY)
+        Money.zero
+        ^^^^^^^^^^ Money.zero is removed, use `Money.new(0, 'CAD')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(0, 'CAD')
+      RUBY
+    end
+
+    it 'registers an offense and corrects Money.zero with currency' do
+      expect_offense(<<~RUBY)
+        Money.zero('EUR')
+        ^^^^^^^^^^^^^^^^^ Money.zero is removed, use `Money.new(0, 'EUR')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Money.new(0, 'EUR')
+      RUBY
+    end
+
+    it 'does not register an offense when using Money.new with a currency' do
+      expect_no_offenses(<<~RUBY)
+        Money.new(0, 'EUR')
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This is to make very clear that this is a sharp tool, since the warnings mentioned in the documentation have happened. The naming is borrowed from core's multi-currency code. Ideally people would not use this at all and explicitly build Money objects with a currency.