### PR TITLE
Update currencies:  kid, mro->mru, vef->ves

### DIFF
--- a/config/currency_historic.yml
+++ b/config/currency_historic.yml
@@ -43,6 +43,21 @@ ghc:
   thousands_separator: ","
   iso_numeric: '288'
   smallest_denomination: 1
+mro:
+  priority: 100
+  iso_code: MRO
+  name: Mauritanian Ouguiya
+  symbol: UM
+  disambiguate_symbol: MRO
+  alternate_symbols: []
+  subunit: Khoums
+  subunit_to_unit: 5
+  symbol_first: false
+  html_entity: ''
+  decimal_mark: "."
+  thousands_separator: ","
+  iso_numeric: '478'
+  smallest_denomination: 1
 mtl:
   priority: 100
   iso_code: MTL
@@ -85,6 +100,20 @@ VEB:
   decimal_mark: ","
   thousands_separator: "."
   iso_numeric: '862'
+  smallest_denomination: 1
+vef:
+  priority: 100
+  iso_code: VEF
+  name: Venezuelan Bolívar fuerte
+  symbol: Bs.F.
+  alternate_symbols: []
+  subunit: Céntimo
+  subunit_to_unit: 100
+  symbol_first: true
+  html_entity: ''
+  decimal_mark: ","
+  thousands_separator: "."
+  iso_numeric: '937'
   smallest_denomination: 1
 zwd:
   priority: 100

--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -1454,6 +1454,9 @@ mru:
   disambiguate_symbol: MRU
   alternate_symbols: []
   subunit: Khoums
+  # MRU actually has 5 Khoums per Ouguiya, but we treat it as if it has no subunits.
+  # We do this because the Khoum's value is so small that it's not likely to be relevant in an online transaction,
+  # and we suspect that, when our payment partners add support for MRU, they're likely to ignore subunits.
   subunit_to_unit: 1
   symbol_first: false
   html_entity: ''

--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -1446,11 +1446,12 @@ mop:
   thousands_separator: ","
   iso_numeric: '446'
   smallest_denomination: 10
-mro:
+mru:
   priority: 100
-  iso_code: MRO
-  name: Mauritanian Ouguiya
+  iso_code: MRU
+  name: Mauritanian New Ouguiya
   symbol: UM
+  disambiguate_symbol: MRU
   alternate_symbols: []
   subunit: Khoums
   subunit_to_unit: 5
@@ -1458,7 +1459,7 @@ mro:
   html_entity: ''
   decimal_mark: "."
   thousands_separator: ","
-  iso_numeric: '478'
+  iso_numeric: '929'
   smallest_denomination: 1
 mur:
   priority: 100
@@ -2300,11 +2301,11 @@ uzs:
   thousands_separator: ","
   iso_numeric: '860'
   smallest_denomination: 100
-vef:
+ves:
   priority: 100
-  iso_code: VEF
-  name: Venezuelan Bolívar fuerte
-  symbol: Bs.F.
+  iso_code: VES
+  name: Venezuelan Bolívar soberano
+  symbol: Bs.S.
   alternate_symbols: []
   subunit: Céntimo
   subunit_to_unit: 100
@@ -2312,8 +2313,11 @@ vef:
   html_entity: ''
   decimal_mark: ","
   thousands_separator: "."
-  iso_numeric: '937'
-  smallest_denomination: 1
+  iso_numeric: '928'
+  # "On 20 August 2018, [...] New coins in denominations of 50 céntimos and 1 bolívar soberano, and new banknotes
+  #  in denominations of 2, 5, 10, 20, 50, 100, 200 and 500 bolívares soberanos were introduced."
+  # Source: https://en.wikipedia.org/wiki/Venezuelan_bol%C3%ADvar
+  smallest_denomination: 50
 vnd:
   priority: 100
   iso_code: VND

--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -1454,7 +1454,7 @@ mru:
   disambiguate_symbol: MRU
   alternate_symbols: []
   subunit: Khoums
-  subunit_to_unit: 5
+  subunit_to_unit: 1
   symbol_first: false
   html_entity: ''
   decimal_mark: "."

--- a/config/currency_non_iso.yml
+++ b/config/currency_non_iso.yml
@@ -14,6 +14,25 @@ jep:
   thousands_separator: ","
   iso_numeric: ''
   smallest_denomination: 1
+kid:
+  # The Kiribati Dollar is pegged 1:1 to the AUD, but banknotes and coins in both currencies circulate interchangeably.
+  # "Although Kiribati retained 1 and 2 cents coins well after Australia demoted theirs,
+  #  redundancy and devaluation has slowly removed these coins from general circulation."
+  # Source:  https://en.wikipedia.org/wiki/Kiribati_dollar
+  priority: 100
+  iso_code: KID
+  name: Kiribati Dollar
+  symbol: "$"
+  disambiguate_symbol: KID
+  alternate_symbols: []
+  subunit: Cent
+  subunit_to_unit: 100
+  symbol_first: true
+  html_entity: "$"
+  decimal_mark: "."
+  thousands_separator: ","
+  iso_numeric: ''
+  smallest_denomination: 5
 ggp:
   priority: 100
   iso_code: GGP


### PR DESCRIPTION
KID is pegged 1:1 to the AUD and circulates interchangeably in Kiribati.
MRU replaces MRO at 10:1.
VES replaces VEF at 100000:1