### PR TITLE
Handle to_s for amounts larger than float precision

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -207,11 +207,20 @@ class Money
   end
 
   def to_s(style = nil)
-    case style
+    units = case style
     when :legacy_dollars
-      sprintf("%.2f", value)
+      2
     when :amount, nil
-      sprintf("%.#{currency.minor_units}f", value)
+      currency.minor_units
+    else
+      raise ArgumentError, "Unexpected style: #{style}"
+    end
+
+    rounded_value = value.round(units)
+    if units == 0
+      sprintf("%d", rounded_value)
+    else
+      sprintf("%d.%0#{units}d", rounded_value.truncate, rounded_value.frac * (10 ** units))
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s(:amount)).to eq("1")
   end
 
+  it "to_s rounds when  more fractions than currency allows" do
+    expect(Money.new("9.999", "USD").to_s).to eq("10.00")
+    expect(Money.new("9.889", "USD").to_s).to eq("9.89")
+  end
+
+  it "to_s does not round when fractions same as currency allows" do
+    expect(Money.new("1.25", "USD").to_s).to eq("1.25")
+    expect(Money.new("9.99", "USD").to_s).to eq("9.99")
+    expect(Money.new("9.999", "BHD").to_s).to eq("9.999")
+  end
+
+  it "to_s does not round if amount is larger than float allows" do
+    expect(Money.new("99999999999999.99", "USD").to_s).to eq("99999999999999.99")
+    expect(Money.new("999999999999999999.99", "USD").to_s).to eq("999999999999999999.99")
+  end
+
+  it "to_s raises ArgumentError on unsupported style" do
+    expect{ money.to_s(:some_weird_style) }.to raise_error(ArgumentError)
+  end
+
   it "as_json as a float with 2 decimal places" do
     expect(money.as_json).to eq("1.00")
   end


### PR DESCRIPTION
Fix https://github.com/Shopify/money/issues/211.

The crux of the issue is that some numbers, like `99999999999999.91`, `99999999999999.99`, etc., cannot be represented as floats:

```
irb(main):001:0> 99999999999999.91
=> 99999999999999.9
irb(main):002:0> 99999999999999.99
=> 99999999999999.98
```

The old `to_s` method used the `f` field for `sprintf`, which essentially converts the `Money` amount `BigDecimal` to a float, then to a string.

This PR changes the implementation of `to_s` so that we don't use float as an intermediate representation. Unfortunately, it's a bit messy. It's inspired by https://stackoverflow.com/a/24892562. Feedback and suggestions for improvement more than welcome.