### PR TITLE
Correctly render negative numbers

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -220,7 +220,9 @@ class Money
     if units == 0
       sprintf("%d", rounded_value)
     else
-      sprintf("%d.%0#{units}d", rounded_value.truncate, rounded_value.frac * (10 ** units))
+      sign = rounded_value < 0 ? '-' : ''
+      rounded_value = rounded_value.abs
+      sprintf("%s%d.%0#{units}d", sign, rounded_value.truncate, rounded_value.frac * (10 ** units))
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s(:amount)).to eq("1")
   end
 
+  it "to_s correctly displays negative numbers" do
+    expect((-money).to_s).to eq("-1.00")
+    expect((-amount_money).to_s).to eq("-1.23")
+    expect((-non_fractional_money).to_s).to eq("-1")
+    expect((-Money.new("0.05")).to_s).to eq("-0.05")
+  end
+
   it "to_s rounds when  more fractions than currency allows" do
     expect(Money.new("9.999", "USD").to_s).to eq("10.00")
     expect(Money.new("9.889", "USD").to_s).to eq("9.89")


### PR DESCRIPTION
Follow-up to #212. Correctly render e.g. `-1.23` as `"-1.23", not `"-1.-23"`. 