### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: ['2.6', '2.7', '3.0']
 
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - uses: actions/cache@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.6, 2.7, 3.0]
 
     name: Ruby ${{ matrix.ruby }}
     steps:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -93,7 +93,7 @@ class Money
   def initialize(value, currency)
     raise ArgumentError if value.nan?
     @currency = Helpers.value_to_currency(currency)
-    @value = value.round(@currency.minor_units)
+    @value = BigDecimal(value.round(@currency.minor_units))
     freeze
   end
 

--- a/money.gemspec
+++ b/money.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  s.add_development_dependency("bundler", ">= 1.5")
+  s.add_development_dependency("bundler")
   s.add_development_dependency("simplecov", ">= 0")
   s.add_development_dependency("rails", "~> 6.0")
   s.add_development_dependency("rspec", "~> 3.2")

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -963,4 +963,10 @@ RSpec.describe "Money" do
       expect(money.currency.iso_code).to eq('EUR')
     end
   end
+
+  describe '#to_yaml' do
+    it 'returns a yaml representation' do
+      expect(Money.new(100, 'JPY').to_yaml).to eq("--- !ruby/object:Money\nvalue: '100.0'\ncurrency: JPY\n")
+    end
+  end
 end


### PR DESCRIPTION
In Ruby 3.0 `BigDecimal#round(0)` returns an Integer https://bugs.ruby-lang.org/issues/12780#note-9

Because of this with currencies such as `JPY` which have no sub units, `@value` sometimes end up an Integer which later break when calling `@value.to_s('F')`.

cc @jusleg (somehow GitHub won't let me add you as reviewer)