### PR TITLE
Remove legacy cents/from_cents methods

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -35,10 +35,6 @@ class Money
       parser.parse(*args, **kwargs)
     end
 
-    def from_cents(cents, currency = nil)
-      new(cents.round.to_f / 100, currency)
-    end
-
     def from_subunits(subunits, currency_iso, format: :iso4217)
       currency = Helpers.value_to_currency(currency_iso)
 
@@ -104,11 +100,6 @@ class Money
   def encode_with(coder)
     coder['value'] = @value.to_s('F')
     coder['currency'] = @currency.iso_code
-  end
-
-  def cents
-    # Money.deprecate('`money.cents` is deprecated and will be removed in the next major release. Please use `money.subunits` instead. Keep in mind, subunits are currency aware.')
-    (value * 100).to_i
   end
 
   def subunits(format: :iso4217)
@@ -241,10 +232,6 @@ class Money
       rounded_value = rounded_value.abs
       sprintf("%s%d.%0#{units}d", sign, rounded_value.truncate, rounded_value.frac * (10 ** units))
     end
-  end
-
-  def to_liquid
-    cents
   end
 
   def to_json(options = {})

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -247,11 +247,6 @@ RSpec.describe "Money" do
     expect((1.50 * Money.new(1.00))).to eq(Money.new(1.50))
   end
 
-  it "is multipliable by a cents amount" do
-    expect((Money.new(1.00) * 0.50)).to eq(Money.new(0.50))
-    expect((0.50 * Money.new(1.00))).to eq(Money.new(0.50))
-  end
-
   it "is multipliable by a rational" do
     expect((Money.new(3.3) * Rational(1, 12))).to eq(Money.new(0.28))
     expect((Rational(1, 12) * Money.new(3.3))).to eq(Money.new(0.28))
@@ -306,10 +301,6 @@ RSpec.describe "Money" do
     expect { Money.new(55.00) / 55 }.to raise_error(RuntimeError)
   end
 
-  it "returns cents in to_liquid" do
-    expect(Money.new(1.00).to_liquid).to eq(100)
-  end
-
   it "returns cents in to_json" do
     expect(Money.new(1.00).to_json).to eq("1.00")
   end
@@ -330,19 +321,7 @@ RSpec.describe "Money" do
     expect(Money.new(1.50).to_f.to_s).to eq("1.5")
   end
 
-  it "is creatable from an integer value in cents" do
-    expect(Money.from_cents(1950)).to eq(Money.new(19.50))
-  end
-
-  it "is creatable from an integer value of 0 in cents" do
-    expect(Money.from_cents(0)).to eq(Money.new)
-  end
-
-  it "is creatable from a float cents amount" do
-    expect(Money.from_cents(1950.5)).to eq(Money.new(19.51))
-  end
-
-  describe '#from_subunits' do 
+  describe '#from_subunits' do
     it "creates Money object from an integer value in cents and currency" do
       expect(Money.from_subunits(1950, 'CAD')).to eq(Money.new(19.50))
     end
@@ -620,10 +599,6 @@ RSpec.describe "Money" do
     end
 
     it "returns cents as 100 cents" do
-      expect(money.cents).to eq(100)
-    end
-
-    it "returns cents as 100 cents" do
       expect(money.subunits).to eq(100)
     end
 
@@ -783,20 +758,6 @@ RSpec.describe "Money" do
   end
 
   describe "from_amount quacks like RubyMoney" do
-    it "accepts numeric values" do
-      expect(Money.from_amount(1)).to eq Money.from_cents(1_00)
-      expect(Money.from_amount(1.0)).to eq Money.from_cents(1_00)
-      expect(Money.from_amount(BigDecimal("1"))).to eq Money.from_cents(1_00)
-    end
-
-    it "accepts string values" do
-      expect(Money.from_amount("1")).to eq Money.from_cents(1_00)
-    end
-
-    it "accepts nil values" do
-      expect(Money.from_amount(nil)).to eq Money.from_cents(0)
-    end
-
     it "accepts an optional currency parameter" do
       expect { Money.from_amount(1, "CAD") }.to_not raise_error
     end


### PR DESCRIPTION
These methods were not doing the right thing and have outlived their usefulness since subunits/from_subunits have existed for a long time - leaving these around just creates confusion as https://github.com/Shopify/money/issues/220 has shown.

I have no idea why we even had a to_liquid method here since we don't do anything Liquid - the couple of apps that use both gems can monkeypatch their required behaviour back in but should not burden dozens of either apps with this concern.