### PR TITLE
Add hash method to currency so that it matches the implementation of eql?

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -50,6 +50,10 @@ class Money
       self.class == other.class && iso_code == other.iso_code
     end
 
+    def hash
+      [ self.class, iso_code ].hash
+    end
+
     def compatible?(other)
       other.is_a?(NullCurrency) || eql?(other)
     end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe "Currency" do
     end
   end
 
+  describe "#hash" do
+    specify "equal currencies from different loaders have the same hash" do
+      currency_1 = Money::Currency.find('USD')
+      currency_2 = YAML.load(Money::Currency.find('USD').to_yaml)
+
+      expect(currency_1.eql?(currency_2)).to eq(true)
+      expect(currency_1.hash).to eq(currency_2.hash)
+    end
+  end
+
   describe "==" do
     it "returns true when both objects have the same currency" do
       expect(currency == Money.new(1, 'USD').currency).to eq(true)


### PR DESCRIPTION
### Problem
When the same currency is created at different times with different currency loaders, the `eql?` method will return `true` but the `hash` method will return a different value for each Currency instance.

This causes methods like `Array.uniq` and `Array.to_set` to treat the currencies as unique, even though `eql?` and `==` return true.

As per the [Ruby docs](https://ruby-doc.org/core-2.7.1/Object.html#method-i-eql-3F), it is best practice to override the `hash` method whenever implementing the `eql?` and `==` methods so that they are consistent with each other:

> The eql? method returns true if obj and other refer to the same hash key. This is used by Hash to test members for equality. For any pair of objects where eql? returns true, the hash value of both objects must be equal. So any subclass that overrides eql? should also override hash appropriately.

This discrepancy between `eql?` and `hash` is currently blocking work on [this issue](https://github.com/Shopify/subscriptions/issues/1394), where we want to use `MultiCurrency.MoneyBag.allocate_max_amounts` to distribute a discount across multiple monies (see [the PoC](https://github.com/Shopify/shopify/pull/273067)).  Every money that we use in `allocate_max_amounts` has the same currency, but depending on circumstances, the currency may come from a cache and was created with a different currency loader, so it has a different hash value.  Subsequently, an error is raised when the allocator checks that all currencies are the same using `uniq`, which thinks the currencies are different because the hash values are different:

https://github.com/Shopify/money/blob/master/lib/money/allocator.rb#L108-L111

### Solution
Implement `Currency.hash` so that it returns the hash of the same attributes that are used in `Currency.eql?`, namely `class` and `iso_code`.

### Testing
Ran a full CI in Shopify/shopify with these changes: https://github.com/Shopify/shopify/pull/274515.  The test failures are all related to other breaking changes in the Money gem, not related to the new `Currency.hash` definition.