### PR TITLE
Remove default currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,6 @@ currency.symbol   #=> '$'
 currency.disambiguate_symbol #=> 'US$'
 ```
 
-### Default Currency
-
-By default `Money` defaults to Money::NullCurrency as its currency. This is a
-global variable that can be changed using:
-
-``` ruby
-Money.default_currency = Money::Currency.new("USD")
-```
-
 In web apps you might want to set the default currency on a per request basis.
 In Rails you can do this with an around action, for example:
 

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -45,7 +45,10 @@ class Money
       when Money::Currency, Money::NullCurrency
         currency
       when nil, ''
-        default = Money.current_currency || Money.default_currency
+        default = Money.current_currency || begin
+          Money.deprecate("nil or '' currency argument given, falling back to Money::NULL_CURRENCY")
+          Money::NULL_CURRENCY
+        end
         raise(ArgumentError, 'missing currency') if default.nil? || default == ''
         value_to_currency(default)
       when 'xxx', 'XXX'

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -11,7 +11,7 @@ class Money
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
 
   class << self
-    attr_accessor :parser, :default_currency
+    attr_accessor :parser
 
     def new(value = 0, currency = nil)
       value = Helpers.value_to_decimal(value)
@@ -60,7 +60,7 @@ class Money
       Thread.current[:money_currency] = currency
     end
 
-    # Set Money.default_currency inside the supplied block, resets it to
+    # Set Money.current_currency inside the supplied block, resets it to
     # the previous value when done to prevent leaking state. Similar to
     # I18n.with_locale and ActiveSupport's Time.use_zone. This won't affect
     # instances being created with explicitly set currency.
@@ -76,7 +76,6 @@ class Money
 
     def default_settings
       self.parser = MoneyParser
-      self.default_currency = Money::NULL_CURRENCY
     end
   end
   default_settings
@@ -89,7 +88,8 @@ class Money
   end
 
   def init_with(coder)
-    initialize(Helpers.value_to_decimal(coder['value']), coder['currency'])
+    currency = coder['currency'] || Money::NULL_CURRENCY
+    initialize(Helpers.value_to_decimal(coder['value']), currency)
   end
 
   def encode_with(coder)

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -8,96 +8,96 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses parenthesis as a negative amount eg (99.00)" do
-      expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00))
+      expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00, 'CAD'))
     end
 
     it "parses parenthesis as a negative amount regardless of currency sign" do
-      expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00))
+      expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00, 'CAD'))
     end
 
     it "parses an empty string to $0" do
-      expect(@parser.parse("")).to eq(Money.new)
+      expect(@parser.parse("")).to eq(Money.new(0, 'CAD'))
     end
 
     it "parses an invalid string to $0" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("no money")).to eq(Money.new)
+      expect(@parser.parse("no money")).to eq(Money.new(0, 'CAD'))
     end
 
     it "parses a single digit integer string" do
-      expect(@parser.parse("1")).to eq(Money.new(1.00))
+      expect(@parser.parse("1")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a double digit integer string" do
-      expect(@parser.parse("10")).to eq(Money.new(10.00))
+      expect(@parser.parse("10")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses an integer string amount with a leading $" do
-      expect(@parser.parse("$1")).to eq(Money.new(1.00))
+      expect(@parser.parse("$1")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a float string amount" do
-      expect(@parser.parse("1.37")).to eq(Money.new(1.37))
+      expect(@parser.parse("1.37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string amount with a leading $" do
-      expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
+      expect(@parser.parse("$1.37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string with a single digit after the decimal" do
-      expect(@parser.parse("10.0")).to eq(Money.new(10.00))
+      expect(@parser.parse("10.0")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses a float string with two digits after the decimal" do
-      expect(@parser.parse("10.00")).to eq(Money.new(10.00))
+      expect(@parser.parse("10.00")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a negative integer amount in the hundreds" do
-      expect(@parser.parse("-100")).to eq(Money.new(-100.00))
+      expect(@parser.parse("-100")).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses an integer amount in the hundreds" do
-      expect(@parser.parse("410")).to eq(Money.new(410.00))
+      expect(@parser.parse("410")).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
+      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
+      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses negative $1.00" do
-      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
+      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00, 'CAD'))
     end
 
     it "parses a negative cents amount" do
-      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
+      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0.123")).to eq(Money.new(0.12))
+      expect(@parser.parse("0.123")).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple leading - signs" do
-      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple - signs" do
-      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
+      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12, 'CAD'))
     end
   end
 
@@ -107,49 +107,49 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses dollar amount $1,00 with leading $" do
-      expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
+      expect(@parser.parse("$1,00")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
-      expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
+      expect(@parser.parse("$1,37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses thousands amount" do
       Money.with_currency(Money::NULL_CURRENCY) do
-        expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+        expect(@parser.parse("1.000")).to eq(Money.new(1000.00, 'CAD'))
       end
     end
 
     it "parses negative hundreds amount" do
-      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
+      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses positive hundreds amount" do
-      expect(@parser.parse("410,00")).to eq(Money.new(410.00))
+      expect(@parser.parse("410,00")).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
+      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
+      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0,123")).to eq(Money.new(0.12))
+      expect(@parser.parse("0,123")).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12, 'CAD'))
     end
   end
 
@@ -159,47 +159,47 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses 50.0" do
-      expect(@parser.parse("50.0")).to eq(Money.new(50.00))
+      expect(@parser.parse("50.0")).to eq(Money.new(50.00, 'CAD'))
     end
 
     it "parses 50.1" do
-      expect(@parser.parse("50.1")).to eq(Money.new(50.10))
+      expect(@parser.parse("50.1")).to eq(Money.new(50.10, 'CAD'))
     end
 
     it "parses 50.2" do
-      expect(@parser.parse("50.2")).to eq(Money.new(50.20))
+      expect(@parser.parse("50.2")).to eq(Money.new(50.20, 'CAD'))
     end
 
     it "parses 50.3" do
-      expect(@parser.parse("50.3")).to eq(Money.new(50.30))
+      expect(@parser.parse("50.3")).to eq(Money.new(50.30, 'CAD'))
     end
 
     it "parses 50.4" do
-      expect(@parser.parse("50.4")).to eq(Money.new(50.40))
+      expect(@parser.parse("50.4")).to eq(Money.new(50.40, 'CAD'))
     end
 
     it "parses 50.5" do
-      expect(@parser.parse("50.5")).to eq(Money.new(50.50))
+      expect(@parser.parse("50.5")).to eq(Money.new(50.50, 'CAD'))
     end
 
     it "parses 50.6" do
-      expect(@parser.parse("50.6")).to eq(Money.new(50.60))
+      expect(@parser.parse("50.6")).to eq(Money.new(50.60, 'CAD'))
     end
 
     it "parses 50.7" do
-      expect(@parser.parse("50.7")).to eq(Money.new(50.70))
+      expect(@parser.parse("50.7")).to eq(Money.new(50.70, 'CAD'))
     end
 
     it "parses 50.8" do
-      expect(@parser.parse("50.8")).to eq(Money.new(50.80))
+      expect(@parser.parse("50.8")).to eq(Money.new(50.80, 'CAD'))
     end
 
     it "parses 50.9" do
-      expect(@parser.parse("50.9")).to eq(Money.new(50.90))
+      expect(@parser.parse("50.9")).to eq(Money.new(50.90, 'CAD'))
     end
 
     it "parses 50.10" do
-      expect(@parser.parse("50.10")).to eq(Money.new(50.10))
+      expect(@parser.parse("50.10")).to eq(Money.new(50.10, 'CAD'))
     end
   end
 end

--- a/spec/accounting_money_parser_spec.rb
+++ b/spec/accounting_money_parser_spec.rb
@@ -2,102 +2,113 @@
 require 'spec_helper'
 
 RSpec.describe AccountingMoneyParser do
+  describe "without currency argument" do
+    before(:each) do
+      @parser = AccountingMoneyParser.new
+    end
+
+    it "logs a deprecation and uses NullCurrency" do
+      expect(Money).to receive(:deprecate).with("nil or '' currency argument given, falling back to Money::NULL_CURRENCY")
+      expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00, Money::NULL_CURRENCY))
+    end
+  end
+
   describe "parsing of amounts with period decimal separator" do
     before(:each) do
       @parser = AccountingMoneyParser.new
     end
 
     it "parses parenthesis as a negative amount eg (99.00)" do
-      expect(@parser.parse("(99.00)")).to eq(Money.new(-99.00, 'CAD'))
+      expect(@parser.parse("(99.00)", 'CAD')).to eq(Money.new(-99.00, 'CAD'))
     end
 
     it "parses parenthesis as a negative amount regardless of currency sign" do
-      expect(@parser.parse("($99.00)")).to eq(Money.new(-99.00, 'CAD'))
+      expect(@parser.parse("($99.00)", 'CAD')).to eq(Money.new(-99.00, 'CAD'))
     end
 
     it "parses an empty string to $0" do
-      expect(@parser.parse("")).to eq(Money.new(0, 'CAD'))
+      expect(@parser.parse("", 'CAD')).to eq(Money.new(0, 'CAD'))
     end
 
     it "parses an invalid string to $0" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("no money")).to eq(Money.new(0, 'CAD'))
+      expect(@parser.parse("no money", 'CAD')).to eq(Money.new(0, 'CAD'))
     end
 
     it "parses a single digit integer string" do
-      expect(@parser.parse("1")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("1", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a double digit integer string" do
-      expect(@parser.parse("10")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses an integer string amount with a leading $" do
-      expect(@parser.parse("$1")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("$1", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a float string amount" do
-      expect(@parser.parse("1.37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("1.37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string amount with a leading $" do
-      expect(@parser.parse("$1.37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("$1.37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string with a single digit after the decimal" do
-      expect(@parser.parse("10.0")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10.0", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses a float string with two digits after the decimal" do
-      expect(@parser.parse("10.00")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10.00", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish $1.00 Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish$1.00Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a negative integer amount in the hundreds" do
-      expect(@parser.parse("-100")).to eq(Money.new(-100.00, 'CAD'))
+      expect(@parser.parse("-100", 'CAD')).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses an integer amount in the hundreds" do
-      expect(@parser.parse("410")).to eq(Money.new(410.00, 'CAD'))
+      expect(@parser.parse("410", 'CAD')).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00, 'CAD'))
+      expect(@parser.parse("100,000.00", 'CAD')).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00, 'CAD'))
+      expect(@parser.parse("-100,000.00", 'CAD')).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses negative $1.00" do
-      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00, 'CAD'))
+      expect(@parser.parse("-1.00", 'CAD')).to eq(Money.new(-1.00, 'CAD'))
     end
 
     it "parses a negative cents amount" do
-      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90, 'CAD'))
+      expect(@parser.parse("-0.90", 'CAD')).to eq(Money.new(-0.90, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0.123")).to eq(Money.new(0.12, 'CAD'))
+      expect(@parser.parse("0.123", 'CAD')).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("-0.123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple leading - signs" do
-      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("--0.123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple - signs" do
-      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("--0.123--", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
   end
 
@@ -107,49 +118,49 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses dollar amount $1,00 with leading $" do
-      expect(@parser.parse("$1,00")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("$1,00", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
-      expect(@parser.parse("$1,37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("$1,37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish $1,00 Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish$1,00Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses thousands amount" do
       Money.with_currency(Money::NULL_CURRENCY) do
-        expect(@parser.parse("1.000")).to eq(Money.new(1000.00, 'CAD'))
+        expect(@parser.parse("1.000", 'CAD')).to eq(Money.new(1000.00, 'CAD'))
       end
     end
 
     it "parses negative hundreds amount" do
-      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00, 'CAD'))
+      expect(@parser.parse("-100,00", 'CAD')).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses positive hundreds amount" do
-      expect(@parser.parse("410,00")).to eq(Money.new(410.00, 'CAD'))
+      expect(@parser.parse("410,00", 'CAD')).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00, 'CAD'))
+      expect(@parser.parse("100.000,00", 'CAD')).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00, 'CAD'))
+      expect(@parser.parse("-100.000,00", 'CAD')).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0,123")).to eq(Money.new(0.12, 'CAD'))
+      expect(@parser.parse("0,123", 'CAD')).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("-0,123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
   end
 
@@ -159,47 +170,47 @@ RSpec.describe AccountingMoneyParser do
     end
 
     it "parses 50.0" do
-      expect(@parser.parse("50.0")).to eq(Money.new(50.00, 'CAD'))
+      expect(@parser.parse("50.0", 'CAD')).to eq(Money.new(50.00, 'CAD'))
     end
 
     it "parses 50.1" do
-      expect(@parser.parse("50.1")).to eq(Money.new(50.10, 'CAD'))
+      expect(@parser.parse("50.1", 'CAD')).to eq(Money.new(50.10, 'CAD'))
     end
 
     it "parses 50.2" do
-      expect(@parser.parse("50.2")).to eq(Money.new(50.20, 'CAD'))
+      expect(@parser.parse("50.2", 'CAD')).to eq(Money.new(50.20, 'CAD'))
     end
 
     it "parses 50.3" do
-      expect(@parser.parse("50.3")).to eq(Money.new(50.30, 'CAD'))
+      expect(@parser.parse("50.3", 'CAD')).to eq(Money.new(50.30, 'CAD'))
     end
 
     it "parses 50.4" do
-      expect(@parser.parse("50.4")).to eq(Money.new(50.40, 'CAD'))
+      expect(@parser.parse("50.4", 'CAD')).to eq(Money.new(50.40, 'CAD'))
     end
 
     it "parses 50.5" do
-      expect(@parser.parse("50.5")).to eq(Money.new(50.50, 'CAD'))
+      expect(@parser.parse("50.5", 'CAD')).to eq(Money.new(50.50, 'CAD'))
     end
 
     it "parses 50.6" do
-      expect(@parser.parse("50.6")).to eq(Money.new(50.60, 'CAD'))
+      expect(@parser.parse("50.6", 'CAD')).to eq(Money.new(50.60, 'CAD'))
     end
 
     it "parses 50.7" do
-      expect(@parser.parse("50.7")).to eq(Money.new(50.70, 'CAD'))
+      expect(@parser.parse("50.7", 'CAD')).to eq(Money.new(50.70, 'CAD'))
     end
 
     it "parses 50.8" do
-      expect(@parser.parse("50.8")).to eq(Money.new(50.80, 'CAD'))
+      expect(@parser.parse("50.8", 'CAD')).to eq(Money.new(50.80, 'CAD'))
     end
 
     it "parses 50.9" do
-      expect(@parser.parse("50.9")).to eq(Money.new(50.90, 'CAD'))
+      expect(@parser.parse("50.9", 'CAD')).to eq(Money.new(50.90, 'CAD'))
     end
 
     it "parses 50.10" do
-      expect(@parser.parse("50.10")).to eq(Money.new(50.10, 'CAD'))
+      expect(@parser.parse("50.10", 'CAD')).to eq(Money.new(50.10, 'CAD'))
     end
   end
 end

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Allocator" do
     end
   end
 
-  def new_allocator(amount, currency = nil)
+  def new_allocator(amount, currency = 'CAD')
     Money::Allocator.new(Money.new(amount, currency))
   end
 end

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 RSpec.describe "Allocator" do
   describe "allocate"do
     specify "#allocate takes no action when one gets all" do
-      expect(new_allocator(5).allocate([1])).to eq([Money.new(5)])
+      expect(new_allocator(5).allocate([1])).to eq([Money.new(5, 'CAD')])
     end
 
     specify "#allocate does not lose pennies" do
       moneys = new_allocator(0.05).allocate([0.3,0.7])
-      expect(moneys[0]).to eq(Money.new(0.02))
-      expect(moneys[1]).to eq(Money.new(0.03))
+      expect(moneys[0]).to eq(Money.new(0.02, 'CAD'))
+      expect(moneys[1]).to eq(Money.new(0.03, 'CAD'))
     end
 
     specify "#allocate does not lose dollars with non-decimal currency" do
@@ -38,14 +38,14 @@ RSpec.describe "Allocator" do
 
     specify "#allocate will use rationals if provided" do
       splits = [128400,20439,14589,14589,25936].map{ |num| Rational(num, 203953) } # sums to > 1 if converted to float
-      expect(new_allocator(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
+      expect(new_allocator(2.25).allocate(splits)).to eq([Money.new(1.42, 'CAD'), Money.new(0.23, 'CAD'), Money.new(0.16, 'CAD'), Money.new(0.16, 'CAD'), Money.new(0.28, 'CAD')])
     end
 
     specify "#allocate will convert rationals with high precision" do
       ratios = [Rational(1, 1), Rational(0)]
-      expect(new_allocator("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12"), Money.new(0, Money::NULL_CURRENCY)])
+      expect(new_allocator("858993456.12").allocate(ratios)).to eq([Money.new("858993456.12", 'CAD'), Money.new(0, Money::NULL_CURRENCY)])
       ratios = [Rational(1, 6), Rational(5, 6)]
-      expect(new_allocator("3.00").allocate(ratios)).to eq([Money.new("0.50"), Money.new("2.50")])
+      expect(new_allocator("3.00").allocate(ratios)).to eq([Money.new("0.50", 'CAD'), Money.new("2.50", 'CAD')])
     end
 
     specify "#allocate doesn't raise with weird negative rational ratios" do
@@ -55,14 +55,14 @@ RSpec.describe "Allocator" do
 
     specify "#allocate fills pennies from beginning to end with roundrobin strategy" do
       moneys = new_allocator(0.05).allocate([0.3,0.7], :roundrobin)
-      expect(moneys[0]).to eq(Money.new(0.02))
-      expect(moneys[1]).to eq(Money.new(0.03))
+      expect(moneys[0]).to eq(Money.new(0.02, 'CAD'))
+      expect(moneys[1]).to eq(Money.new(0.03, 'CAD'))
     end
 
     specify "#allocate fills pennies from end to beginning with roundrobin_reverse strategy" do
       moneys = new_allocator(0.05).allocate([0.3,0.7], :roundrobin_reverse)
-      expect(moneys[0]).to eq(Money.new(0.01))
-      expect(moneys[1]).to eq(Money.new(0.04))
+      expect(moneys[0]).to eq(Money.new(0.01, 'CAD'))
+      expect(moneys[1]).to eq(Money.new(0.04, 'CAD'))
     end
 
     specify "#allocate raise ArgumentError when invalid strategy is provided" do
@@ -71,16 +71,16 @@ RSpec.describe "Allocator" do
 
     specify "#allocate does not raise ArgumentError when invalid splits types are provided" do
       moneys = new_allocator(0.03).allocate([0.5, 0.5], :roundrobin)
-      expect(moneys[0]).to eq(Money.new(0.02))
-      expect(moneys[1]).to eq(Money.new(0.01))
+      expect(moneys[0]).to eq(Money.new(0.02, 'CAD'))
+      expect(moneys[1]).to eq(Money.new(0.01, 'CAD'))
     end
   end
 
   describe 'allocate_max_amounts' do
     specify "#allocate_max_amounts returns the weighted allocation without exceeding the maxima when there is room for the remainder" do
       expect(
-        new_allocator(30.75).allocate_max_amounts([Money.new(26), Money.new(4.75)]),
-      ).to eq([Money.new(26), Money.new(4.75)])
+        new_allocator(30.75).allocate_max_amounts([Money.new(26, 'CAD'), Money.new(4.75, 'CAD')]),
+      ).to eq([Money.new(26, 'CAD'), Money.new(4.75, 'CAD')])
     end
 
     specify "#allocate_max_amounts returns the weighted allocation without exceeding the maxima when there is room for the remainder with currency" do
@@ -107,26 +107,26 @@ RSpec.describe "Allocator" do
 
     specify "#allocate_max_amounts drops the remainder when returning the weighted allocation without exceeding the maxima when there is no room for the remainder" do
       expect(
-        new_allocator(30.75).allocate_max_amounts([Money.new(26), Money.new(4.74)]),
-      ).to eq([Money.new(26), Money.new(4.74)])
+        new_allocator(30.75).allocate_max_amounts([Money.new(26, 'CAD'), Money.new(4.74, 'CAD')]),
+      ).to eq([Money.new(26, 'CAD'), Money.new(4.74, 'CAD')])
     end
 
     specify "#allocate_max_amounts returns the weighted allocation when there is no remainder" do
       expect(
-        new_allocator(30).allocate_max_amounts([Money.new(15), Money.new(15)]),
-      ).to eq([Money.new(15), Money.new(15)])
+        new_allocator(30).allocate_max_amounts([Money.new(15, 'CAD'), Money.new(15, 'CAD')]),
+      ).to eq([Money.new(15, 'CAD'), Money.new(15, 'CAD')])
     end
 
     specify "#allocate_max_amounts allocates the remainder round-robin when the maxima are not reached" do
       expect(
-        new_allocator(1).allocate_max_amounts([Money.new(33), Money.new(33), Money.new(33)]),
-      ).to eq([Money.new(0.34), Money.new(0.33), Money.new(0.33)])
+        new_allocator(1).allocate_max_amounts([Money.new(33, 'CAD'), Money.new(33, 'CAD'), Money.new(33, 'CAD')]),
+      ).to eq([Money.new(0.34, 'CAD'), Money.new(0.33, 'CAD'), Money.new(0.33, 'CAD')])
     end
 
     specify "#allocate_max_amounts allocates up to the maxima specified" do
       expect(
-        new_allocator(100).allocate_max_amounts([Money.new(5), Money.new(2)]),
-      ).to eq([Money.new(5), Money.new(2)])
+        new_allocator(100).allocate_max_amounts([Money.new(5, 'CAD'), Money.new(2, 'CAD')]),
+      ).to eq([Money.new(5, 'CAD'), Money.new(2, 'CAD')])
     end
 
     specify "#allocate_max_amounts supports all-zero maxima" do
@@ -137,8 +137,8 @@ RSpec.describe "Allocator" do
 
     specify "#allocate_max_amounts allocates the right amount without rounding error" do
       expect(
-        new_allocator(24.2).allocate_max_amounts([Money.new(46), Money.new(46), Money.new(50), Money.new(50),Money.new(50)]),
-        ).to eq([Money.new(4.6), Money.new(4.6), Money.new(5), Money.new(5), Money.new(5)])
+        new_allocator(24.2).allocate_max_amounts([Money.new(46, 'CAD'), Money.new(46, 'CAD'), Money.new(50, 'CAD'), Money.new(50, 'CAD'),Money.new(50, 'CAD')]),
+        ).to eq([Money.new(4.6, 'CAD'), Money.new(4.6, 'CAD'), Money.new(5, 'CAD'), Money.new(5, 'CAD'), Money.new(5, 'CAD')])
     end
   end
 

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 RSpec.shared_examples_for "an object supporting to_money" do
   it "supports to_money" do
-    expect(@value.to_money).to eq(@money)
+    expect(@value.to_money('CAD')).to eq(@money)
     expect(@value.to_money('CAD').currency).to eq(Money::Currency.find!('CAD'))
   end
 end
@@ -11,52 +11,52 @@ end
 RSpec.describe Integer do
   before(:each) do
     @value = 1
-    @money = Money.new("1.00")
+    @money = Money.new("1.00", 'CAD')
   end
 
   it_should_behave_like "an object supporting to_money"
 
   it "parses 0 to Money.zero" do
-    expect(0.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(0.to_money('CAD')).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
 RSpec.describe Float do
   before(:each) do
     @value = 1.23
-    @money = Money.new("1.23")
+    @money = Money.new("1.23", 'CAD')
   end
 
   it_should_behave_like "an object supporting to_money"
 
   it "parses 0.0 to Money.zero" do
-    expect(0.0.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(0.0.to_money('CAD')).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
 RSpec.describe String do
   before(:each) do
     @value = "1.23"
-    @money = Money.new(@value)
+    @money = Money.new(@value, 'CAD')
   end
 
   it_should_behave_like "an object supporting to_money"
 
   it "parses an empty string to Money.zero" do
-    expect(''.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
-    expect(' '.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(''.to_money('CAD')).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(' '.to_money('CAD')).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end
 
 RSpec.describe BigDecimal do
   before(:each) do
     @value = BigDecimal("1.23")
-    @money = Money.new("1.23")
+    @money = Money.new("1.23", 'CAD')
   end
 
   it_should_behave_like "an object supporting to_money"
 
   it "parses a zero BigDecimal to Money.zero" do
-    expect(BigDecimal("-0.000").to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    expect(BigDecimal("-0.000").to_money('CAD')).to eq(Money.new(0, Money::NULL_CURRENCY))
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Money::Helpers do
 
   describe 'value_to_decimal' do
     let (:amount) { BigDecimal('1.23') }
-    let (:money) { Money.new(amount) }
+    let (:money) { Money.new(amount, 'CAD') }
 
     it 'returns the value of a money object' do
       expect(subject.value_to_decimal(money)).to eq(amount)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -65,12 +65,14 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_currency(Money::NULL_CURRENCY)).to be_a(Money::NullCurrency)
     end
 
-    it 'returns the default currency when value is nil' do
-      expect(subject.value_to_currency(nil)).to eq(Money.default_currency)
+    it 'logs a deprecation and returns NullCurrency when value is nil' do
+      expect(Money).to receive(:deprecate)
+      expect(subject.value_to_currency(nil)).to eq(Money::NULL_CURRENCY)
     end
 
-    it 'returns the default currency when value is empty' do
-      expect(subject.value_to_currency('')).to eq(Money.default_currency)
+    it 'logs a deprecation and returns NullCurrency when value is empty' do
+      expect(Money).to receive(:deprecate)
+      expect(subject.value_to_currency('')).to eq(Money::NULL_CURRENCY)
     end
 
     it 'returns the default currency when value is xxx' do

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MoneyParser do
     it "parses an invalid string when not strict" do
       expect(Money).to receive(:deprecate).twice
       expect(@parser.parse("no money")).to eq(Money.new(0, Money::NULL_CURRENCY))
-      expect(@parser.parse("1..")).to eq(Money.new(1))
+      expect(@parser.parse("1..")).to eq(Money.new(1, 'CAD'))
     end
 
     it "parses raise with an invalid string and strict option" do
@@ -23,68 +23,68 @@ RSpec.describe MoneyParser do
     end
 
     it "parses a single digit integer string" do
-      expect(@parser.parse("1")).to eq(Money.new(1.00))
+      expect(@parser.parse("1")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a double digit integer string" do
-      expect(@parser.parse("10")).to eq(Money.new(10.00))
+      expect(@parser.parse("10")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses an integer string amount with a leading $" do
-      expect(@parser.parse("$1")).to eq(Money.new(1.00))
+      expect(@parser.parse("$1")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a float string amount" do
-      expect(@parser.parse("1.37")).to eq(Money.new(1.37))
+      expect(@parser.parse("1.37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string amount with a leading $" do
-      expect(@parser.parse("$1.37")).to eq(Money.new(1.37))
+      expect(@parser.parse("$1.37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string with a single digit after the decimal" do
-      expect(@parser.parse("10.0")).to eq(Money.new(10.00))
+      expect(@parser.parse("10.0")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses a float string with two digits after the decimal" do
-      expect(@parser.parse("10.00")).to eq(Money.new(10.00))
+      expect(@parser.parse("10.00")).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a negative integer amount in the hundreds" do
-      expect(@parser.parse("-100")).to eq(Money.new(-100.00))
+      expect(@parser.parse("-100")).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses an integer amount in the hundreds" do
-      expect(@parser.parse("410")).to eq(Money.new(410.00))
+      expect(@parser.parse("410")).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses an amount ending with a ." do
-      expect(@parser.parse("1.")).to eq(Money.new(1))
-      expect(@parser.parse("100,000.")).to eq(Money.new(100_000))
+      expect(@parser.parse("1.")).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse("100,000.")).to eq(Money.new(100_000, 'CAD'))
     end
 
     it "parses an amount starting with a ." do
-      expect(@parser.parse(".12")).to eq(Money.new(0.12))
+      expect(@parser.parse(".12")).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00))
+      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00))
+      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator with no decimal" do
-      expect(@parser.parse("1,000")).to eq(Money.new(1_000))
+      expect(@parser.parse("1,000")).to eq(Money.new(1_000, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator with no decimal with a currency" do
@@ -96,27 +96,27 @@ RSpec.describe MoneyParser do
     end
 
     it "parses negative $1.00" do
-      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
+      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00, 'CAD'))
     end
 
     it "parses a negative cents amount" do
-      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
+      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0.123")).to eq(Money.new(0.12))
+      expect(@parser.parse("0.123")).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple leading - signs" do
-      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple - signs" do
-      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12))
+      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses a positive amount with a thousands dot separator currency and no decimal" do
@@ -136,16 +136,16 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with more than 3 decimals correctly" do
-      expect(@parser.parse("1.11111111")).to eq(Money.new(1.11))
+      expect(@parser.parse("1.11111111")).to eq(Money.new(1.11, 'CAD'))
     end
 
     it "parses amount with multiple consistent thousands delimiters" do
-      expect(@parser.parse("1.111.111")).to eq(Money.new(1_111_111))
+      expect(@parser.parse("1.111.111")).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("1.1.11.111")).to eq(Money.new(1_111_111))
+      expect(@parser.parse("1.1.11.111")).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do
@@ -155,48 +155,48 @@ RSpec.describe MoneyParser do
 
   describe "parsing of amounts with comma decimal separator" do
     it "parses dollar amount $1,00 with leading $" do
-      expect(@parser.parse("$1,00")).to eq(Money.new(1.00))
+      expect(@parser.parse("$1,00")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
-      expect(@parser.parse("$1,37")).to eq(Money.new(1.37))
+      expect(@parser.parse("$1,37")).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00))
+      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses negative hundreds amount" do
-      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00))
+      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses positive hundreds amount" do
-      expect(@parser.parse("410,00")).to eq(Money.new(410.00))
+      expect(@parser.parse("410,00")).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00))
+      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00))
+      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses amount ending with a comma" do
-      expect(@parser.parse("1,")).to eq(Money.new(1))
-      expect(@parser.parse("100.000,")).to eq(Money.new(100_000))
+      expect(@parser.parse("1,")).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse("100.000,")).to eq(Money.new(100_000, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0,123")).to eq(Money.new(0.12))
+      expect(@parser.parse("0,123")).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12))
+      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses amount 2 decimals correctly" do
@@ -208,16 +208,16 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with more than 3 decimals correctly and a currency" do
-      expect(@parser.parse("1,11111111", 'CAD')).to eq(Money.new(111_111_111))
+      expect(@parser.parse("1,11111111", 'CAD')).to eq(Money.new(111_111_111, 'CAD'))
     end
 
     it "parses amount with multiple consistent thousands delimiters" do
-      expect(@parser.parse("1,111,111")).to eq(Money.new(1_111_111))
+      expect(@parser.parse("1,111,111")).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("1,1,11,111")).to eq(Money.new(1_111_111))
+      expect(@parser.parse("1,1,11,111")).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do
@@ -272,71 +272,71 @@ RSpec.describe MoneyParser do
 
   describe "parsing of decimal cents amounts from 0 to 10" do
     it "parses 50.0" do
-      expect(@parser.parse("50.0")).to eq(Money.new(50.00))
+      expect(@parser.parse("50.0")).to eq(Money.new(50.00, 'CAD'))
     end
 
     it "parses 50.1" do
-      expect(@parser.parse("50.1")).to eq(Money.new(50.10))
+      expect(@parser.parse("50.1")).to eq(Money.new(50.10, 'CAD'))
     end
 
     it "parses 50.2" do
-      expect(@parser.parse("50.2")).to eq(Money.new(50.20))
+      expect(@parser.parse("50.2")).to eq(Money.new(50.20, 'CAD'))
     end
 
     it "parses 50.3" do
-      expect(@parser.parse("50.3")).to eq(Money.new(50.30))
+      expect(@parser.parse("50.3")).to eq(Money.new(50.30, 'CAD'))
     end
 
     it "parses 50.4" do
-      expect(@parser.parse("50.4")).to eq(Money.new(50.40))
+      expect(@parser.parse("50.4")).to eq(Money.new(50.40, 'CAD'))
     end
 
     it "parses 50.5" do
-      expect(@parser.parse("50.5")).to eq(Money.new(50.50))
+      expect(@parser.parse("50.5")).to eq(Money.new(50.50, 'CAD'))
     end
 
     it "parses 50.6" do
-      expect(@parser.parse("50.6")).to eq(Money.new(50.60))
+      expect(@parser.parse("50.6")).to eq(Money.new(50.60, 'CAD'))
     end
 
     it "parses 50.7" do
-      expect(@parser.parse("50.7")).to eq(Money.new(50.70))
+      expect(@parser.parse("50.7")).to eq(Money.new(50.70, 'CAD'))
     end
 
     it "parses 50.8" do
-      expect(@parser.parse("50.8")).to eq(Money.new(50.80))
+      expect(@parser.parse("50.8")).to eq(Money.new(50.80, 'CAD'))
     end
 
     it "parses 50.9" do
-      expect(@parser.parse("50.9")).to eq(Money.new(50.90))
+      expect(@parser.parse("50.9")).to eq(Money.new(50.90, 'CAD'))
     end
 
     it "parses 50.10" do
-      expect(@parser.parse("50.10")).to eq(Money.new(50.10))
+      expect(@parser.parse("50.10")).to eq(Money.new(50.10, 'CAD'))
     end
   end
 
   describe "parsing of integer" do
     it "parses 1" do
-      expect(@parser.parse(1)).to eq(Money.new(1))
+      expect(@parser.parse(1)).to eq(Money.new(1, 'CAD'))
     end
 
     it "parses 50" do
-      expect(@parser.parse(50)).to eq(Money.new(50))
+      expect(@parser.parse(50)).to eq(Money.new(50, 'CAD'))
     end
   end
 
   describe "parsing of float" do
     it "parses 1.00" do
-      expect(@parser.parse(1.00)).to eq(Money.new(1.00))
+      expect(@parser.parse(1.00)).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses 1.32" do
-      expect(@parser.parse(1.32)).to eq(Money.new(1.32))
+      expect(@parser.parse(1.32)).to eq(Money.new(1.32, 'CAD'))
     end
 
     it "parses 1.234" do
-      expect(@parser.parse(1.234)).to eq(Money.new(1.234))
+      expect(@parser.parse(1.234)).to eq(Money.new(1.234, 'CAD'))
     end
   end
 
@@ -353,7 +353,7 @@ RSpec.describe MoneyParser do
       '123,4567.89',
       ].each do |number|
         it "parses #{number}" do
-          expect(@parser.parse(number)).to eq(Money.new(1_234_567.89))
+          expect(@parser.parse(number)).to eq(Money.new(1_234_567.89, 'CAD'))
         end
       end
   end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -6,85 +6,92 @@ RSpec.describe MoneyParser do
     @parser = MoneyParser
   end
 
+  describe "without currency argument" do
+    it "logs a deprecation and uses NullCurrency" do
+      expect(Money).to receive(:deprecate).with("nil or '' currency argument given, falling back to Money::NULL_CURRENCY")
+      expect(@parser.parse("1.00")).to eq(Money.new(1.00, Money::NULL_CURRENCY))
+    end
+  end
+
   describe "parsing of amounts with period decimal separator" do
     it "parses an empty string to $0" do
-      expect(@parser.parse("")).to eq(Money.new(0, Money::NULL_CURRENCY))
+      expect(@parser.parse("", 'CAD')).to eq(Money.new(0, 'CAD'))
     end
 
     it "parses an invalid string when not strict" do
       expect(Money).to receive(:deprecate).twice
-      expect(@parser.parse("no money")).to eq(Money.new(0, Money::NULL_CURRENCY))
-      expect(@parser.parse("1..")).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse("no money", 'CAD')).to eq(Money.new(0, 'CAD'))
+      expect(@parser.parse("1..", 'CAD')).to eq(Money.new(1, 'CAD'))
     end
 
     it "parses raise with an invalid string and strict option" do
-      expect { @parser.parse("no money", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
-      expect { @parser.parse("1..1", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
+      expect { @parser.parse("no money", 'CAD', strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
+      expect { @parser.parse("1..1", 'CAD', strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
     end
 
     it "parses a single digit integer string" do
-      expect(@parser.parse("1")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("1", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a double digit integer string" do
-      expect(@parser.parse("10")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses an integer string amount with a leading $" do
-      expect(@parser.parse("$1")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("$1", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a float string amount" do
-      expect(@parser.parse("1.37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("1.37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string amount with a leading $" do
-      expect(@parser.parse("$1.37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("$1.37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses a float string with a single digit after the decimal" do
-      expect(@parser.parse("10.0")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10.0", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses a float string with two digits after the decimal" do
-      expect(@parser.parse("10.00")).to eq(Money.new(10.00, 'CAD'))
+      expect(@parser.parse("10.00", 'CAD')).to eq(Money.new(10.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1.00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish $1.00 Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1.00Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish$1.00Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses a negative integer amount in the hundreds" do
-      expect(@parser.parse("-100")).to eq(Money.new(-100.00, 'CAD'))
+      expect(@parser.parse("-100", 'CAD')).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses an integer amount in the hundreds" do
-      expect(@parser.parse("410")).to eq(Money.new(410.00, 'CAD'))
+      expect(@parser.parse("410", 'CAD')).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses an amount ending with a ." do
-      expect(@parser.parse("1.")).to eq(Money.new(1, 'CAD'))
-      expect(@parser.parse("100,000.")).to eq(Money.new(100_000, 'CAD'))
+      expect(@parser.parse("1.", 'CAD')).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse("100,000.", 'CAD')).to eq(Money.new(100_000, 'CAD'))
     end
 
     it "parses an amount starting with a ." do
-      expect(@parser.parse(".12")).to eq(Money.new(0.12, 'CAD'))
+      expect(@parser.parse(".12", 'CAD')).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100,000.00")).to eq(Money.new(100_000.00, 'CAD'))
+      expect(@parser.parse("100,000.00", 'CAD')).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100,000.00")).to eq(Money.new(-100_000.00, 'CAD'))
+      expect(@parser.parse("-100,000.00", 'CAD')).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator with no decimal" do
-      expect(@parser.parse("1,000")).to eq(Money.new(1_000, 'CAD'))
+      expect(@parser.parse("1,000", 'CAD')).to eq(Money.new(1_000, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator with no decimal with a currency" do
@@ -96,27 +103,27 @@ RSpec.describe MoneyParser do
     end
 
     it "parses negative $1.00" do
-      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00, 'CAD'))
+      expect(@parser.parse("-1.00", 'CAD')).to eq(Money.new(-1.00, 'CAD'))
     end
 
     it "parses a negative cents amount" do
-      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90, 'CAD'))
+      expect(@parser.parse("-0.90", 'CAD')).to eq(Money.new(-0.90, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0.123")).to eq(Money.new(0.12, 'CAD'))
+      expect(@parser.parse("0.123", 'CAD')).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("-0.123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple leading - signs" do
-      expect(@parser.parse("--0.123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("--0.123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses negative amount with multiple - signs" do
-      expect(@parser.parse("--0.123--")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("--0.123--", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses a positive amount with a thousands dot separator currency and no decimal" do
@@ -136,67 +143,67 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with more than 3 decimals correctly" do
-      expect(@parser.parse("1.11111111")).to eq(Money.new(1.11, 'CAD'))
+      expect(@parser.parse("1.11111111", 'CAD')).to eq(Money.new(1.11, 'CAD'))
     end
 
     it "parses amount with multiple consistent thousands delimiters" do
-      expect(@parser.parse("1.111.111")).to eq(Money.new(1_111_111, 'CAD'))
+      expect(@parser.parse("1.111.111", 'CAD')).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("1.1.11.111")).to eq(Money.new(1_111_111, 'CAD'))
+      expect(@parser.parse("1.1.11.111", 'CAD')).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do
-      expect { @parser.parse("1.1.11.111", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
+      expect { @parser.parse("1.1.11.111", 'CAD', strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
     end
   end
 
   describe "parsing of amounts with comma decimal separator" do
     it "parses dollar amount $1,00 with leading $" do
-      expect(@parser.parse("$1,00")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("$1,00", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses dollar amount $1,37 with leading $, and non-zero cents" do
-      expect(@parser.parse("$1,37")).to eq(Money.new(1.37, 'CAD'))
+      expect(@parser.parse("$1,37", 'CAD')).to eq(Money.new(1.37, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by whitespace and garbage" do
-      expect(@parser.parse("Rubbish $1,00 Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish $1,00 Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses the amount from an amount surrounded by garbage" do
-      expect(@parser.parse("Rubbish$1,00Rubbish")).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse("Rubbish$1,00Rubbish", 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses negative hundreds amount" do
-      expect(@parser.parse("-100,00")).to eq(Money.new(-100.00, 'CAD'))
+      expect(@parser.parse("-100,00", 'CAD')).to eq(Money.new(-100.00, 'CAD'))
     end
 
     it "parses positive hundreds amount" do
-      expect(@parser.parse("410,00")).to eq(Money.new(410.00, 'CAD'))
+      expect(@parser.parse("410,00", 'CAD')).to eq(Money.new(410.00, 'CAD'))
     end
 
     it "parses a positive amount with a thousands separator" do
-      expect(@parser.parse("100.000,00")).to eq(Money.new(100_000.00, 'CAD'))
+      expect(@parser.parse("100.000,00", 'CAD')).to eq(Money.new(100_000.00, 'CAD'))
     end
 
     it "parses a negative amount with a thousands separator" do
-      expect(@parser.parse("-100.000,00")).to eq(Money.new(-100_000.00, 'CAD'))
+      expect(@parser.parse("-100.000,00", 'CAD')).to eq(Money.new(-100_000.00, 'CAD'))
     end
 
     it "parses amount ending with a comma" do
-      expect(@parser.parse("1,")).to eq(Money.new(1, 'CAD'))
-      expect(@parser.parse("100.000,")).to eq(Money.new(100_000, 'CAD'))
+      expect(@parser.parse("1,", 'CAD')).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse("100.000,", 'CAD')).to eq(Money.new(100_000, 'CAD'))
     end
 
     it "parses amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("0,123")).to eq(Money.new(0.12, 'CAD'))
+      expect(@parser.parse("0,123", 'CAD')).to eq(Money.new(0.12, 'CAD'))
     end
 
     it "parses negative amount with 3 decimals and 0 dollar amount" do
-      expect(@parser.parse("-0,123")).to eq(Money.new(-0.12, 'CAD'))
+      expect(@parser.parse("-0,123", 'CAD')).to eq(Money.new(-0.12, 'CAD'))
     end
 
     it "parses amount 2 decimals correctly" do
@@ -212,16 +219,16 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with multiple consistent thousands delimiters" do
-      expect(@parser.parse("1,111,111")).to eq(Money.new(1_111_111, 'CAD'))
+      expect(@parser.parse("1,111,111", 'CAD')).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
       expect(Money).to receive(:deprecate).once
-      expect(@parser.parse("1,1,11,111")).to eq(Money.new(1_111_111, 'CAD'))
+      expect(@parser.parse("1,1,11,111", 'CAD')).to eq(Money.new(1_111_111, 'CAD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do
-      expect { @parser.parse("1,1,11,111", strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
+      expect { @parser.parse("1,1,11,111", 'CAD', strict: true) }.to raise_error(MoneyParser::MoneyFormatError)
     end
   end
 
@@ -272,71 +279,71 @@ RSpec.describe MoneyParser do
 
   describe "parsing of decimal cents amounts from 0 to 10" do
     it "parses 50.0" do
-      expect(@parser.parse("50.0")).to eq(Money.new(50.00, 'CAD'))
+      expect(@parser.parse("50.0", 'CAD')).to eq(Money.new(50.00, 'CAD'))
     end
 
     it "parses 50.1" do
-      expect(@parser.parse("50.1")).to eq(Money.new(50.10, 'CAD'))
+      expect(@parser.parse("50.1", 'CAD')).to eq(Money.new(50.10, 'CAD'))
     end
 
     it "parses 50.2" do
-      expect(@parser.parse("50.2")).to eq(Money.new(50.20, 'CAD'))
+      expect(@parser.parse("50.2", 'CAD')).to eq(Money.new(50.20, 'CAD'))
     end
 
     it "parses 50.3" do
-      expect(@parser.parse("50.3")).to eq(Money.new(50.30, 'CAD'))
+      expect(@parser.parse("50.3", 'CAD')).to eq(Money.new(50.30, 'CAD'))
     end
 
     it "parses 50.4" do
-      expect(@parser.parse("50.4")).to eq(Money.new(50.40, 'CAD'))
+      expect(@parser.parse("50.4", 'CAD')).to eq(Money.new(50.40, 'CAD'))
     end
 
     it "parses 50.5" do
-      expect(@parser.parse("50.5")).to eq(Money.new(50.50, 'CAD'))
+      expect(@parser.parse("50.5", 'CAD')).to eq(Money.new(50.50, 'CAD'))
     end
 
     it "parses 50.6" do
-      expect(@parser.parse("50.6")).to eq(Money.new(50.60, 'CAD'))
+      expect(@parser.parse("50.6", 'CAD')).to eq(Money.new(50.60, 'CAD'))
     end
 
     it "parses 50.7" do
-      expect(@parser.parse("50.7")).to eq(Money.new(50.70, 'CAD'))
+      expect(@parser.parse("50.7", 'CAD')).to eq(Money.new(50.70, 'CAD'))
     end
 
     it "parses 50.8" do
-      expect(@parser.parse("50.8")).to eq(Money.new(50.80, 'CAD'))
+      expect(@parser.parse("50.8", 'CAD')).to eq(Money.new(50.80, 'CAD'))
     end
 
     it "parses 50.9" do
-      expect(@parser.parse("50.9")).to eq(Money.new(50.90, 'CAD'))
+      expect(@parser.parse("50.9", 'CAD')).to eq(Money.new(50.90, 'CAD'))
     end
 
     it "parses 50.10" do
-      expect(@parser.parse("50.10")).to eq(Money.new(50.10, 'CAD'))
+      expect(@parser.parse("50.10", 'CAD')).to eq(Money.new(50.10, 'CAD'))
     end
   end
 
   describe "parsing of integer" do
     it "parses 1" do
-      expect(@parser.parse(1)).to eq(Money.new(1, 'CAD'))
+      expect(@parser.parse(1, 'CAD')).to eq(Money.new(1, 'CAD'))
     end
 
     it "parses 50" do
-      expect(@parser.parse(50)).to eq(Money.new(50, 'CAD'))
+      expect(@parser.parse(50, 'CAD')).to eq(Money.new(50, 'CAD'))
     end
   end
 
   describe "parsing of float" do
     it "parses 1.00" do
-      expect(@parser.parse(1.00)).to eq(Money.new(1.00, 'CAD'))
+      expect(@parser.parse(1.00, 'CAD')).to eq(Money.new(1.00, 'CAD'))
     end
 
     it "parses 1.32" do
-      expect(@parser.parse(1.32)).to eq(Money.new(1.32, 'CAD'))
+      expect(@parser.parse(1.32, 'CAD')).to eq(Money.new(1.32, 'CAD'))
     end
 
     it "parses 1.234" do
-      expect(@parser.parse(1.234)).to eq(Money.new(1.234, 'CAD'))
+      expect(@parser.parse(1.234, 'CAD')).to eq(Money.new(1.234, 'CAD'))
     end
   end
 
@@ -353,7 +360,7 @@ RSpec.describe MoneyParser do
       '123,4567.89',
       ].each do |number|
         it "parses #{number}" do
-          expect(@parser.parse(number)).to eq(Money.new(1_234_567.89, 'CAD'))
+          expect(@parser.parse(number, 'CAD')).to eq(Money.new(1_234_567.89, 'CAD'))
         end
       end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -9,20 +9,6 @@ RSpec.describe "Money" do
   let (:non_fractional_money) { Money.new(1, 'JPY') }
   let (:zero_money) { Money.new(0, 'CAD') }
 
-  context "default currency not set" do
-    before(:each) do
-      @default_currency = Money.default_currency
-      Money.default_currency = nil
-    end
-    after(:each) do
-      Money.default_currency = @default_currency
-    end
-
-    it "raises an error" do
-      expect { money }.to raise_error(ArgumentError)
-    end
-  end
-
   it ".zero has no currency" do
     expect(Money.new(0, Money::NULL_CURRENCY).currency).to be_a(Money::NullCurrency)
   end
@@ -817,7 +803,7 @@ RSpec.describe "Money" do
           value: !ruby/object:BigDecimal 18:0.75E3
           cents: 75000
       EOS
-      expect(money).to be == Money.new(750, 'CAD')
+      expect(money).to be == Money.new(750, Money::NULL_CURRENCY)
       expect(money.value).to be_a BigDecimal
     end
 
@@ -828,7 +814,7 @@ RSpec.describe "Money" do
           value: 750.00
           cents: 75000
       EOS
-      expect(money).to be == Money.new(750, 'CAD')
+      expect(money).to be == Money.new(750, Money::NULL_CURRENCY)
       expect(money.value).to be_a BigDecimal
     end
   end
@@ -872,29 +858,6 @@ RSpec.describe "Money" do
       end
 
       expect(money.currency.iso_code).to eq('USD')
-    end
-
-    context "with .default_currency set" do
-      before(:each) { Money.default_currency = Money::Currency.new('EUR') }
-      after(:each) { Money.default_currency = Money::NULL_CURRENCY }
-
-      it "can be nested and falls back to default_currency outside of the blocks" do
-        money2, money3 = nil
-
-        money1 = Money.new(1.00, 'CAD')
-        Money.with_currency('CAD') do
-          Money.with_currency('USD') do
-            money2 = Money.new(1.00, 'CAD')
-          end
-          money3 = Money.new(1.00, 'CAD')
-        end
-        money4 = Money.new(1.00, 'CAD')
-
-        expect(money1.currency.iso_code).to eq('EUR')
-        expect(money2.currency.iso_code).to eq('USD')
-        expect(money3.currency.iso_code).to eq('CAD')
-        expect(money4.currency.iso_code).to eq('EUR')
-      end
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -704,7 +704,7 @@ RSpec.describe "Money" do
     end
 
     it "supports parenthesis from AccountingMoneyParser" do
-      expect(Money.parse("($5.00)")).to eq(Money.new(-5, 'CAD'))
+      expect(Money.parse("($5.00)", 'CAD')).to eq(Money.new(-5, 'CAD'))
     end
 
     it "supports parenthesis from AccountingMoneyParser for .to_money" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ require 'active_record'
 require 'money'
 
 Money.active_support_deprecator.behavior = :raise
-Money.default_currency = Money::Currency.new('CAD')
 
 ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":memory:"
 


### PR DESCRIPTION
Most (all?) apps never set this. It doesn't force developers to be explicit leading to problems because they didn't mean to use `NullCurrency`.

To use to Rubocop rule to automatically fix most of these deprecations, see the readme: https://github.com/Shopify/money#rubocop