### PR TITLE
Fix historic Ghanaian Cedi ISO code

### DIFF
--- a/config/currency_historic.yml
+++ b/config/currency_historic.yml
@@ -29,7 +29,7 @@ eek:
   smallest_denomination: 5
 ghc:
   priority: 100
-  iso_code: GHS
+  iso_code: GHC
   name: Ghanaian Cedi
   symbol: "₵"
   disambiguate_symbol: GH₵


### PR DESCRIPTION
The configured historic Ghanaian Cedi ISO code was the same as the
current Ghanaian Cedi ISO code, GHS. However, the currency with numeric
ISO code 288 should have the ISO code GHC, as per:
https://www.currency-iso.org/dam/downloads/lists/list_three.xml

This PR should fix the immediate concern of https://github.com/Shopify/money/issues/227, but there might still be room to explore a solution for ensuring that there aren't duplicate ISO codes in the currency configs.