### PR TITLE
Fix money column with non money objects and null default currency

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -49,16 +49,14 @@ module MoneyColumn
         return self[column] = nil
       end
 
-      currency_raw_source = options[:currency] || (send(options[:currency_column]) rescue nil)
-
-      if !money.is_a?(Money)
-        return self[column] = Money.new(money, currency_raw_source).value
+      unless money.is_a?(Money)
+        return self[column] = Money::Helpers.value_to_decimal(money)
       end
 
       if options[:currency_read_only]
-        currency_source = Money::Helpers.value_to_currency(currency_raw_source)
-        if currency_raw_source && !money.currency.compatible?(currency_source)
-          Money.deprecate("[money_column] currency mismatch between #{currency_source} and #{money.currency} in column #{column}.")
+        currency = options[:currency] || (send(options[:currency_column]) rescue nil)
+        if currency && !money.currency.compatible?(Money::Helpers.value_to_currency(currency))
+          Money.deprecate("[money_column] currency mismatch between #{currency} and #{money.currency} in column #{column}.")
         end
       else
         self[options[:currency_column]] = money.currency.to_s unless money.no_currency?

--- a/spec/money_column_spec.rb
+++ b/spec/money_column_spec.rb
@@ -114,12 +114,12 @@ RSpec.describe 'MoneyColumn' do
     expect(record.prix.currency.to_s).to eq('CAD')
   end
 
-  it 'handles legacy support for saving floats with correct currency rounding' do
+  it 'handles legacy support for saving floats as provided' do
     record.update(price: 3.2112, prix: 3.2156)
-    expect(record.attributes['price']).to eq(3.21)
+    expect(record.attributes['price']).to eq(3.2112)
     expect(record.price.value).to eq(3.21)
     expect(record.price.currency.to_s).to eq(currency)
-    expect(record.attributes['prix']).to eq(3.22)
+    expect(record.attributes['prix']).to eq(3.2156)
     expect(record.prix.value).to eq(3.22)
     expect(record.prix.currency.to_s).to eq('CAD')
   end
@@ -384,11 +384,17 @@ RSpec.describe 'MoneyColumn' do
       expect(record.price.currency.to_s).to eq('GBP')
     end
 
-    it 'raises missing currency error when input is not a money object' do
-      record.update(currency: nil)
+    it 'raises missing currency error reading a value that was saved using legacy non-money object' do
+      record.update(currency: nil, price: 3)
+      expect { record.price }.to raise_error(ArgumentError, 'missing currency')
+    end
 
-      expect { record.update(price: 3) }
-        .to raise_error(ArgumentError, 'missing currency')
+    it 'handles legacy support for saving price and currency separately' do
+      record.update(currency: nil)
+      record.update(price: 7, currency: 'GBP')
+      record.reload
+      expect(record.price.value).to eq(7)
+      expect(record.price.currency.to_s).to eq('GBP')
     end
   end
 end


### PR DESCRIPTION
Apps using `Money.default_currency = nil` should not raise an exception when a currency is provided. This is not the always the case for money_columns accepting numeric values instead of money objects:
```
MyModel.new(amount: 10, currency: 'USD')
#=> ArgumentError: missing currency
```
This is because when the `amount` attribute writer is called, it does not yet know the currency. In order to solve this issue, this PR reverts back to supporting legacy non-money objects by saving them as is and not converting them to money objects first. 

In doing so it is possible the DB value to be different than the money object value, since no rounding has been applied. This is deemed to be the preferred behaviour since money_column is only in the business of creating money objects from data in the DB and not modifying data before it is saved.

Long term we may want to deprecate saving non money objects in a money_column