### PR TITLE
Fix typo in v1 PR

### DIFF
--- a/lib/money/money_parser.rb
+++ b/lib/money/money_parser.rb
@@ -84,7 +84,7 @@ class MoneyParser
     if number.empty?
       if Money.config.legacy_deprecations && !strict
         Money.deprecate("invalid money strings will raise in the next major release \"#{input}\"")
-        '0'
+        return '0'
       else
         raise MoneyFormatError, "invalid money string: #{input}"
       end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Money" do
     expect{ money.to_s(:some_weird_style) }.to raise_error(ArgumentError)
   end
 
-  it "legacy_deprecations as_json as a float with 2 decimal places" do
+  it "legacy_json_format makes as_json return the legacy format" do
     configure(legacy_json_format: true) do
       expect(Money.new(1, 'CAD').as_json).to eq("1.00")
     end


### PR DESCRIPTION
# Why

Two typos snuck in https://github.com/Shopify/money/pull/231/files

# What

- test name
- return '0' value

No tests are changed because the code worked previously (empty strings are the same as `0` in legacy mode), but was less explicit