### PR TITLE
Only create BigDecimal once

### DIFF
--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -7,6 +7,8 @@ class Money
       super
     end
 
+    ONE = BigDecimal("1")
+
     # Allocates money between different parties without losing pennies.
     # After the mathematically split has been performed, left over pennies will
     # be distributed round-robin amongst the parties. This means that parties
@@ -43,7 +45,7 @@ class Money
       splits.map!(&:to_r)
       allocations = splits.inject(0, :+)
 
-      if (allocations - BigDecimal("1")) > Float::EPSILON
+      if (allocations - ONE) > Float::EPSILON
         raise ArgumentError, "splits add to more than 100%"
       end
 


### PR DESCRIPTION
Calculating suggested refunds spends 9% of the time in `BigDecimal`

This code was added by https://github.com/Shopify/money/pull/29 

<img width="394" alt="Screen Shot 2021-05-10 at 2 57 06 PM" src="https://user-images.githubusercontent.com/647711/117711956-b89bc780-b1a1-11eb-9765-dac5ad9a4c08.png">

<img width="428" alt="Screen Shot 2021-05-10 at 2 58 21 PM" src="https://user-images.githubusercontent.com/647711/117711987-c3565c80-b1a1-11eb-8db1-3533c398c886.png">


### What should reviewers focus on?

I have no context on this gem

@Shopify/core-deliver-returns
