### PR TITLE
Add version to the requires for Money.

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative 'money/version'
 require_relative 'money/money_parser'
 require_relative 'money/helpers'
 require_relative 'money/currency'

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "Money" do
   let (:non_fractional_money) { Money.new(1, 'JPY') }
   let (:zero_money) { Money.new(0) }
 
+  it "has a version" do
+    expect(Money::VERSION).not_to(eq(nil)) 
+  end
+
   context "default currency not set" do
     it "raises an error" do
       configure(default_currency: nil) do


### PR DESCRIPTION
When loading this via the gemspec, such as running tests, the version file is loaded, but for downstream users, it is not loaded, so Money::VERSION is an undefined constant.

I added a test to prove this, but to make the test fail, you need to uncomment the require from the gemspec, and the require_relative I added in lib/money.rb


in Shopify/Shopify

```
pry(main)> Money::VERSION
NameError: uninitialized constant Money::VERSION
```

```
> Money.constants
=> [:Helpers, :Currency, :ReverseOperationProxy, :NullCurrency, :Error, :Allocator, :Type, :IncompatibleCurrencyError, :NULL_CURRENCY]
```

But it's definitely loading from the Gem

```
 Money.const_source_location(:NULL_CURRENCY)
=> ["/usr/local/bundle/gems/shopify-money-0.16.0/lib/money/money.rb", 8]
```

Which does have a version file....
```
$ ls /usr/local/bundle/gems/shopify-money-0.16.0/lib/money/
accounting_money_parser.rb  allocator.rb  core_extensions.rb  currency	currency.rb  deprecations.rb  errors.rb  helpers.rb  money_parser.rb  money.rb	null_currency.rb  version.rb
```