### PR TITLE
default to a StrictMoneyParser

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,7 @@ Money.configure do |config|
   config.legacy_default_currency!
   config.legacy_deprecations!
   config.legacy_json_format!
+  config.parser = MoneyParser
   #...
 end
 ```
@@ -23,30 +24,32 @@ Money.new(1) #=> value: 1, currency: XXX
 ```
 
 #### legacy_deprecations!
+By enabling `legacy_deprecations!` your app will show deprecation warnings instead of raising and will:
 
-invalid money values return zero
+convert invalid money values to zero
 ```ruby
 Money.new('a', 'USD') #=> Money.new(0, 'USD')
 ```
 
-invalid currency is ignored
+ignore invalid currencies
 ```ruby
 Money.new(1, 'ABCD') #=> Money.new(1)
 ```
 
-mathematical operations between objects are allowed
+allow mathematical operations between different currencies
 ```ruby
 Money.new(1, 'USD') + Money.new(1, 'CAD') #=> Money.new(2, 'USD')
 ```
 
-parsing a string with invalid delimiters
+parse a string with invalid delimiters
 ```ruby
 Money.parse('123*12') #=> Money.new(123)
 ```
 
 #### legacy_json_format!
 
-to_json will return only the value (no currency)
+
+By enabling `legacy_json_format!` your app will return only the value (no currency) when calling to_json
 ```ruby
 # with legacy_json_format!
 money.to_json #=> "1"
@@ -55,3 +58,11 @@ money.to_json #=> "1"
 money.to_json #=> { value: 1, currency: 'USD' }
 ```
 
+#### MoneyParser
+
+By setting the parser to `MoneyParser` your app will try to guess if `.` or `,` is a decimal or thousand mark
+
+```ruby
+Money.parse("1,000", "USD") #=> Money.new("1000", "USD")
+Money.parse("1.000", "USD") #=> Money.new("1000", "USD")
+```

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'money/version'
 require_relative 'money/money_parser'
+require_relative 'money/strict_money_parser'
 require_relative 'money/helpers'
 require_relative 'money/currency'
 require_relative 'money/null_currency'

--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -17,7 +17,7 @@ class Money
     end
 
     def initialize
-      @parser = MoneyParser
+      @parser = StrictMoneyParser
       @default_currency = nil
       @legacy_json_format = false
       @legacy_deprecations = false

--- a/lib/money/errors.rb
+++ b/lib/money/errors.rb
@@ -5,4 +5,7 @@ class Money
 
   class IncompatibleCurrencyError < Error
   end
+
+  class ParserError < Error
+  end
 end

--- a/lib/money/strict_money_parser.rb
+++ b/lib/money/strict_money_parser.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Parse an amount from a string
+class StrictMoneyParser
+  def self.parse(value, currency = nil, **options)
+    new.parse(value, currency, **options)
+  end
+
+  def parse(value, currency = nil, *_)
+    if value.nil?
+      raise ArgumentError, "value can't be nil"
+    end
+
+    value = value.to_s.strip
+
+    if value.empty?
+      return Money.new(0, currency)
+    end
+
+    value = value.sub(/\.\z/, "")
+
+    unless value =~ /\A[+-]?(\d+|\d+\.\d+|\.\d+)\z/
+      raise Money::ParserError, "invalid money value #{value}"
+    end
+
+    Money.new(value, currency)
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Money::Config" do
 
   describe 'parser' do
     it 'defaults to MoneyParser' do
-      expect(Money::Config.new.parser).to eq(MoneyParser)
+      expect(Money::Config.new.parser).to eq(StrictMoneyParser)
     end
 
     it 'can be set to a new parser' do

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses an invalid string when not strict" do
-      configure(legacy_deprecations: true) do
+      configure(parser: MoneyParser, legacy_deprecations: true) do
         expect(Money).to receive(:deprecate).twice
         expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
         expect(@parser.parse("1..", 'USD')).to eq(Money.new(1, 'USD'))
@@ -152,7 +152,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
-      configure(legacy_deprecations: true) do
+      configure(parser: MoneyParser, legacy_deprecations: true) do
         expect(Money).to receive(:deprecate).once
         expect(@parser.parse("1.1.11.111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
       end
@@ -226,7 +226,7 @@ RSpec.describe MoneyParser do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
-      configure(legacy_deprecations: true) do
+      configure(parser: MoneyParser, legacy_deprecations: true) do
         expect(Money).to receive(:deprecate).once
         expect(@parser.parse("1,1,11,111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
       end

--- a/spec/strict_money_parser_spec.rb
+++ b/spec/strict_money_parser_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe StrictMoneyParser do
+  before(:each) do
+    @parser = StrictMoneyParser
+  end
+
+  describe "parsing of amounts with period decimal separator" do
+    it "parses an empty string to $0" do
+      expect(@parser.parse("")).to eq(Money.new(0))
+      expect { @parser.parse(nil) }.to raise_error(ArgumentError)
+    end
+
+    it "parses raises with an invalid string" do
+      expect { @parser.parse("no money") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("1..1") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("$1") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("Rubbish $1.00 Rubbish") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("Rubbish$1.00Rubbish") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("--0.123") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("--0.123--") }.to raise_error(Money::ParserError)
+      expect { @parser.parse("100,000.") }.to raise_error(Money::ParserError)
+    end
+
+    it "parses raise with an invalid when a currency is missing" do
+      configure do
+        expect { @parser.parse("1") }.to raise_error(Money::Currency::UnknownCurrency)
+      end
+    end
+
+    it "parses a single digit integer string" do
+      expect(@parser.parse("1")).to eq(Money.new(1.00))
+    end
+
+    it "parses a double digit integer string" do
+      expect(@parser.parse("10")).to eq(Money.new(10.00))
+    end
+
+    it "parses a float string amount" do
+      expect(@parser.parse("1.37")).to eq(Money.new(1.37))
+    end
+
+    it "parses a float string with a single digit after the decimal" do
+      expect(@parser.parse("10.0")).to eq(Money.new(10.00))
+    end
+
+    it "parses a float string with two digits after the decimal" do
+      expect(@parser.parse("10.00")).to eq(Money.new(10.00))
+    end
+
+    it "parses a negative integer amount in the hundreds" do
+      expect(@parser.parse("-100")).to eq(Money.new(-100.00))
+    end
+
+    it "parses an integer amount in the hundreds" do
+      expect(@parser.parse("410")).to eq(Money.new(410.00))
+    end
+
+    it "parses an amount ending with a . raises an error" do
+      expect(@parser.parse("1.")).to eq(Money.new(1))
+    end
+
+    it "parses an amount starting with a ." do
+      expect(@parser.parse(".12")).to eq(Money.new(0.12))
+    end
+
+    it "parses negative $1.00" do
+      expect(@parser.parse("-1.00")).to eq(Money.new(-1.00))
+    end
+
+    it "parses a negative cents amount" do
+      expect(@parser.parse("-0.90")).to eq(Money.new(-0.90))
+    end
+
+    it "parses amount with 3 decimals and 0 dollar amount" do
+      expect(@parser.parse("0.123")).to eq(Money.new(0.12))
+    end
+
+    it "parses negative amount with 3 decimals and 0 dollar amount" do
+      expect(@parser.parse("-0.123")).to eq(Money.new(-0.12))
+    end
+
+    it "parses amount even if currency is usually associated with . thousands separator" do
+      expect(@parser.parse("1.000", 'EUR')).to eq(Money.new(1, 'EUR'))
+      expect(@parser.parse("1.000", 'JOD')).to eq(Money.new(1, 'JOD'))
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1, Money::NULL_CURRENCY))
+    end
+
+    it "parses amount with more than 3 decimals correctly" do
+      expect(@parser.parse("1.11111111")).to eq(Money.new(1.11))
+    end
+  end
+
+  describe "parsing of decimal cents amounts from 0 to 10" do
+    it "parses 50.0" do
+      expect(@parser.parse("50.0")).to eq(Money.new(50.00))
+    end
+
+    it "parses 50.1" do
+      expect(@parser.parse("50.1")).to eq(Money.new(50.10))
+    end
+
+    it "parses 50.2" do
+      expect(@parser.parse("50.2")).to eq(Money.new(50.20))
+    end
+
+    it "parses 50.3" do
+      expect(@parser.parse("50.3")).to eq(Money.new(50.30))
+    end
+
+    it "parses 50.4" do
+      expect(@parser.parse("50.4")).to eq(Money.new(50.40))
+    end
+
+    it "parses 50.5" do
+      expect(@parser.parse("50.5")).to eq(Money.new(50.50))
+    end
+
+    it "parses 50.6" do
+      expect(@parser.parse("50.6")).to eq(Money.new(50.60))
+    end
+
+    it "parses 50.7" do
+      expect(@parser.parse("50.7")).to eq(Money.new(50.70))
+    end
+
+    it "parses 50.8" do
+      expect(@parser.parse("50.8")).to eq(Money.new(50.80))
+    end
+
+    it "parses 50.9" do
+      expect(@parser.parse("50.9")).to eq(Money.new(50.90))
+    end
+
+    it "parses 50.10" do
+      expect(@parser.parse("50.10")).to eq(Money.new(50.10))
+    end
+  end
+
+  describe "parsing of integer" do
+    it "parses 1" do
+      expect(@parser.parse(1)).to eq(Money.new(1))
+    end
+
+    it "parses 50" do
+      expect(@parser.parse(50)).to eq(Money.new(50))
+    end
+  end
+
+  describe "parsing of float" do
+    it "parses 1.00" do
+      expect(@parser.parse(1.00)).to eq(Money.new(1.00))
+    end
+
+    it "parses 1.32" do
+      expect(@parser.parse(1.32)).to eq(Money.new(1.32))
+    end
+
+    it "parses 1.234" do
+      expect(@parser.parse(1.234)).to eq(Money.new(1.234))
+    end
+  end
+
+  describe "parsing money strings with thousands separator raises" do
+    [
+      '1,234,567.89',
+      '1 234 567.89',
+      '1 234 567,89',
+      '1.234.567,89',
+      '1˙234˙567,89',
+      '12,34,567.89',
+      "1'234'567.89",
+      "1'234'567,89",
+      '123,4567.89',
+      ].each do |number|
+        it "parses #{number}" do
+          expect { @parser.parse(number) }.to raise_error(Money::ParserError)
+        end
+      end
+  end
+end


### PR DESCRIPTION
# Why

The current default MoneyParser tries to guess if `.` or `,` is the decimal mark (both are used thought the world). This leads to some unexpected behaviour, especially when the format is known. 

# What

This PR defaults to a strict parser that only considers `.` as the valid decimal mark. This parser does not make any assumptions as to the merchant's locale. This means that we never need to guess if `1.000` is one thousand or one.

It's still possible for legacy app to revert to the old MoneyParser by setting it explicitly in the configs. See `UPGRADING.md`

## Other alternatives:

1. Remove the parsing functionality completely from this gem (create a new gem just for parsing), and rely on `Money.new` instead
2. Accept the locale as an argument to MoneyParser (this may not always work, for example locale `fr_CA` uses `,` as decimal mark, but people with this locale often use `.`)
3. Accept the decimal mark as an optional param 
4. Parse string with currency https://github.com/Shopify/money/pull/97