### PR TITLE
Add Active Job serializer for Money arguments

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -12,5 +12,6 @@ require_relative 'money/deprecations'
 require_relative 'money/accounting_money_parser'
 require_relative 'money/core_extensions'
 require_relative 'money_column' if defined?(ActiveRecord)
+require_relative 'money/railtie' if defined?(Rails::Railtie)
 
 require_relative 'rubocop/cop/money' if defined?(RuboCop)

--- a/lib/money/rails/job_argument_serializer.rb
+++ b/lib/money/rails/job_argument_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Money
+  module Rails
+    class JobArgumentSerializer < ::ActiveJob::Serializers::ObjectSerializer
+      def serialize(money)
+        super("value" => money.value, "currency" => money.currency.iso_code)
+      end
+
+      def deserialize(hash)
+        Money.new(hash["value"], hash["currency"])
+      end
+
+      private
+
+      def klass
+        Money
+      end
+    end
+  end
+end
+

--- a/lib/money/railtie.rb
+++ b/lib/money/railtie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Money
+  class Railtie < Rails::Railtie
+    initializer "shopify-money.setup_active_job_serializer" do
+      ActiveSupport.on_load :active_job do
+        require_relative "rails/job_argument_serializer"
+        ActiveJob::Serializers.add_serializers ::Money::Rails::JobArgumentSerializer
+      end
+    end
+  end
+end

--- a/spec/rails/job_argument_serializer_spec.rb
+++ b/spec/rails/job_argument_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_spec_helper"
+
+RSpec.describe Money::Rails::JobArgumentSerializer do
+  it "roundtrip a Money argument returns the same object" do
+    job = MoneyTestJob.new(value: Money.new(10.21, "BRL"))
+
+    serialized_job = job.serialize
+    serialized_value = serialized_job["arguments"][0]["value"]
+    expect(serialized_value["_aj_serialized"]).to eq("Money::Rails::JobArgumentSerializer")
+    expect(serialized_value["value"]).to eq(BigDecimal("10.21"))
+    expect(serialized_value["currency"]).to eq("BRL")
+
+    job2 = MoneyTestJob.deserialize(serialized_job)
+    job2.send(:deserialize_arguments_if_needed)
+
+    expect(job2.arguments.first[:value]).to eq(Money.new(10.21, "BRL"))
+  end
+end

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "active_job"
+require_relative "spec_helper"
+
+Money::Railtie.initializers.each(&:run)
+
+class MoneyTestJob < ActiveJob::Base
+  def perform(_params)
+  end
+end


### PR DESCRIPTION
Extracted from Shopify core, I noticed some apps cargoculted it so it seemed ripe for extraction. Fun fact: this object was the original reason [custom ActiveJob serializers](https://api.rubyonrails.org/classes/ActiveJob/Serializers/ObjectSerializer.html) were added to Rails 6.

After https://github.com/Shopify/money/pull/237#discussion_r734977395 I tried to make sure this is as decoupled from Rails as possible :) Bringing in these tests also allow us to drop the exclusion of the Railtie in test coverage in that PR.