### PR TITLE
Avoid allocating unecessary Money objects

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -128,12 +128,14 @@ class Money
 
   def +(other)
     arithmetic(other) do |money|
+      return self if money.value == 0 && !no_currency?
       Money.new(value + money.value, calculated_currency(money.currency))
     end
   end
 
   def -(other)
     arithmetic(other) do |money|
+      return self if money.value == 0 && !no_currency?
       Money.new(value - money.value, calculated_currency(money.currency))
     end
   end
@@ -146,6 +148,7 @@ class Money
         raise ArgumentError, "Money objects can only be multiplied by a Numeric"
       end
     end
+    return self if numeric == 1
     Money.new(value.to_r * numeric, currency)
   end
 
@@ -256,15 +259,21 @@ class Money
   end
 
   def abs
-    Money.new(value.abs, currency)
+    abs = value.abs
+    return self if value == abs
+    Money.new(abs, currency)
   end
 
   def floor
-    Money.new(value.floor, currency)
+    floor = value.floor
+    return self if floor == value
+    Money.new(floor, currency)
   end
 
   def round(ndigits=0)
-    Money.new(value.round(ndigits), currency)
+    round = value.round(ndigits)
+    return self if round == value
+    Money.new(round, currency)
   end
 
   def fraction(rate)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -401,6 +401,30 @@ RSpec.describe "Money" do
     end
   end
 
+  it "does not allocate a new money object when multiplying by 1" do
+    expect((money * 1).object_id).to eq(money.object_id)
+  end
+
+  it "does not allocate a new money object when adding 0" do
+    expect((money + 0).object_id).to eq(money.object_id)
+  end
+
+  it "does not allocate a new money object when subtracting 0" do
+    expect((money - 0).object_id).to eq(money.object_id)
+  end
+
+  it "does not allocate when computing absolute value when already positive" do
+    expect((money.abs).object_id).to eq(money.object_id)
+  end
+
+  it "does not allocate when computing floor value when already floored" do
+    expect((money.floor).object_id).to eq(money.object_id)
+  end
+
+  it "does not allocate when computing floor value when already rounded" do
+    expect((money.round).object_id).to eq(money.object_id)
+  end
+
   describe "frozen with amount of $1" do
     let (:money) { Money.new(1.00) }
 


### PR DESCRIPTION
Some mathematical operations on money do not alter the value. Rather than allocating a new money object in these scenarios, return the original object unmodified.

These operations include:
- Multiplying by 1
- Adding 0
- Subtracting 0
- Absolute value of a positive
- Floor of a integer
- Round of an integer

The `*` operation in particular is a huge improvement in performance. Very often we multiply money by `1` (for example, line items on an order, receipt, etc...). I've done analysis and found that multiplying by 1 is very common in our organization (in my domain its ~ 2 unity multiplications for every 1 non unity multiplication), feel free to message me offline if curious.

The additional branching logic adds an overhead in the "must allocate" scenarios. I think the benefit of less GC is still worth it, and of course the improvement in performance in the happy path.

I've benchmarked these operations on a 2019 macbook pro. Each benchmark does a single operation:

```
Calculating -------------------------------------
            * 1 fast      3.885M (± 5.9%) i/s -     19.387M in   5.008294s
            * 1 slow    109.628k (±11.1%) i/s -    547.932k in   5.071054s
            * 2 fast    113.946k (± 7.6%) i/s -    572.728k in   5.059608s
            * 2 slow    115.683k (± 7.7%) i/s -    580.601k in   5.050959s
            + 0 fast    387.724k (±11.7%) i/s -      1.980M in   5.226214s
            + 0 slow    174.708k (± 7.0%) i/s -    875.836k in   5.040234s
            + 1 fast    147.587k (± 6.1%) i/s -    739.000k in   5.026883s
            + 1 slow    170.333k (± 6.0%) i/s -    860.979k in   5.073701s
            - 0 fast    387.046k (± 7.9%) i/s -      1.943M in   5.056525s
            - 0 slow    176.155k (± 6.5%) i/s -    891.212k in   5.082139s
            - 1 fast    196.797k (± 9.2%) i/s -    982.770k in   5.044117s
            - 1 slow    236.461k (± 8.7%) i/s -      1.195M in   5.100167s
         abs >0 fast      1.169M (± 6.8%) i/s -      5.904M in   5.076604s
         abs >0 slow    271.161k (± 5.0%) i/s -      1.360M in   5.027565s
         abs <0 fast    249.919k (± 7.1%) i/s -      1.251M in   5.032736s
         abs <0 slow    259.557k (±10.0%) i/s -      1.299M in   5.069573s
        floor 1 fast    536.839k (±13.2%) i/s -      2.640M in   5.084235s
        floor 1 slow    181.871k (±12.8%) i/s -    884.352k in   5.006957s
      floor 1.1 fast    148.399k (±13.9%) i/s -    721.996k in   5.047952s
      floor 1.1 slow    181.206k (±13.9%) i/s -    898.217k in   5.075678s
        round 1 fast    795.197k (±23.0%) i/s -      3.756M in   5.039355s
        round 1 slow    241.576k (±19.3%) i/s -      1.144M in   5.000179s
      round 1.1 fast    252.630k (± 7.5%) i/s -      1.256M in   5.002092s
      round 1.1 slow    270.853k (± 7.2%) i/s -      1.365M in   5.071662s
```