### PR TITLE
Introduce Money#to_formatted_s for consistency with Active Support

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -222,14 +222,14 @@ class Money
     value
   end
 
-  def to_s(style = nil)
+  def to_formatted_s(style = nil)
     units = case style
     when :legacy_dollars
       2
     when :amount, nil
       currency.minor_units
     else
-      raise ArgumentError, "Unexpected style: #{style}"
+      raise ArgumentError, "Unexpected format: #{style}"
     end
 
     rounded_value = value.round(units)
@@ -241,6 +241,7 @@ class Money
       sprintf("%s%d.%0#{units}d", sign, rounded_value.truncate, rounded_value.frac * (10 ** units))
     end
   end
+  alias_method :to_s, :to_formatted_s
 
   def to_json(options = nil)
     if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s).to eq("1")
   end
 
-  it "to_s with a legacy_dollars style" do
-    expect(amount_money.to_s(:legacy_dollars)).to eq("1.23")
-    expect(non_fractional_money.to_s(:legacy_dollars)).to eq("1.00")
+  it "to_formatted_s with a legacy_dollars style" do
+    expect(amount_money.to_formatted_s(:legacy_dollars)).to eq("1.23")
+    expect(non_fractional_money.to_formatted_s(:legacy_dollars)).to eq("1.00")
   end
 
-  it "to_s with a amount style" do
-    expect(amount_money.to_s(:amount)).to eq("1.23")
-    expect(non_fractional_money.to_s(:amount)).to eq("1")
+  it "to_formatted_s with a amount style" do
+    expect(amount_money.to_formatted_s(:amount)).to eq("1.23")
+    expect(non_fractional_money.to_formatted_s(:amount)).to eq("1")
   end
 
   it "to_s correctly displays negative numbers" do
@@ -104,8 +104,8 @@ RSpec.describe "Money" do
     expect(Money.new("999999999999999999.99", "USD").to_s).to eq("999999999999999999.99")
   end
 
-  it "to_s raises ArgumentError on unsupported style" do
-    expect{ money.to_s(:some_weird_style) }.to raise_error(ArgumentError)
+  it "to_formatted_s raises ArgumentError on unsupported style" do
+    expect{ money.to_formatted_s(:some_weird_style) }.to raise_error(ArgumentError)
   end
 
   it "legacy_json_format makes as_json return the legacy format" do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43772

Most if not all `to_s(format)` are deprecated in Rails 7, having the same `to_formatted_s` interface makes it easier for polymorphic callsites.