### PR TITLE
Add STN and VED, mark STD historic

### DIFF
--- a/config/currency_historic.yml
+++ b/config/currency_historic.yml
@@ -73,6 +73,20 @@ mtl:
   thousands_separator: ","
   iso_numeric: '470'
   smallest_denomination: 1
+std:
+  priority: 100
+  iso_code: STD
+  name: São Tomé and Príncipe Dobra
+  symbol: Db
+  alternate_symbols: []
+  subunit: Cêntimo
+  subunit_to_unit: 100
+  symbol_first: false
+  html_entity: ''
+  decimal_mark: "."
+  thousands_separator: ","
+  iso_numeric: '678'
+  smallest_denomination: 10000
 tmm:
   priority: 100
   iso_code: TMM

--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -2029,9 +2029,9 @@ ssp:
   thousands_separator: ","
   iso_numeric: '728'
   smallest_denomination: 5
-std:
+stn:
   priority: 100
-  iso_code: STD
+  iso_code: STN
   name: São Tomé and Príncipe Dobra
   symbol: Db
   alternate_symbols: []
@@ -2041,8 +2041,8 @@ std:
   html_entity: ''
   decimal_mark: "."
   thousands_separator: ","
-  iso_numeric: '678'
-  smallest_denomination: 10000
+  iso_numeric: '930'
+  smallest_denomination: 1
 svc:
   priority: 100
   iso_code: SVC
@@ -2304,6 +2304,24 @@ uzs:
   thousands_separator: ","
   iso_numeric: '860'
   smallest_denomination: 100
+ved:
+  priority: 100
+  iso_code: VED
+  name: Venezuelan Bolívar soberano
+  symbol: Bs.D.
+  alternate_symbols: []
+  subunit: Céntimo
+  subunit_to_unit: 100
+  symbol_first: true
+  html_entity: ''
+  decimal_mark: ","
+  thousands_separator: "."
+  iso_numeric: '926'
+  # "On 1 Oct 2021, [...] another (redenomination) happened, but called 'Nueva expresión monetaria', 
+  # or new monetary expression, which removed 6 zeroes from the currency without affecting its denomination."
+  # The VED has banknotes in denominations of 5, 10, 20, 50, and 100, and coins in 50 céntimos and 1 Bs.D.
+  # Source: https://en.wikipedia.org/wiki/Venezuelan_bol%C3%ADvar
+  smallest_denomination: 1
 ves:
   priority: 100
   iso_code: VES


### PR DESCRIPTION
STN replaces STD at 1000:1
VED re-expresses VES at 1000000:1

Based on discussion on [this pull request](https://github.com/Shopify/shopify-i18n/pull/1197#pullrequestreview-896404875).

After evaluating currencies on the [ISO 4217 active currencies list](https://docs.google.com/spreadsheets/d/1xPwYYWxOuqb-jK5M3ENk5T-TEz65IQB4/edit#gid=2079806851) that don't exist in `Shopify/money`, @cejaekl made these observations:
 - CUC, CUP, and KPW:  We are prohibited by US law from doing business in :flag-cu: and :flag-kp: , so there's not much point in adding these.
 - STN:  yes, we should definitely add that.  It's a revaluation of STD that was introduced in 2018.
 - SVC was phased out in 2001 (:flag-sv: now uses USD as its official currency), so I don't think there's any point in adding this one.
 - VED:  I'm not sure what to make of this one.  It was introduced in October 2021, and is officially worth 1,000,000 VES (so, 100,000,000,000 VEF, or 100,000,000,000,000 VEB).  But it seems that it's not an official replacement for VES?  I guess it wouldn't hurt to add VED, but I can't imagine that anyone's in much of a hurry to use it; we propose USD as the default currency for shops in :flag-ve: .
 - ZWL:  :flag-zw: basically threw in the towel and admitted that this would no longer be used in 2009, and then all but demonetized it in 2015.  I don't think we need to add this one.

So, in summary, we should be adding STN and perhaps VED.
We will defer to the expertise of @bdewater and the Shopify Money team.