### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
 
     name: Ruby ${{ matrix.ruby }}
     steps:

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Currency" do
   describe "#hash" do
     specify "equal currencies from different loaders have the same hash" do
       currency_1 = Money::Currency.find('USD')
-      currency_2 = YAML.load(Money::Currency.find('USD').to_yaml)
+      currency_2 = yaml_load(Money::Currency.find('USD').to_yaml)
 
       expect(currency_1.eql?(currency_2)).to eq(true)
       expect(currency_1.hash).to eq(currency_2.hash)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -854,17 +854,17 @@ RSpec.describe "Money" do
 
   describe "YAML deserialization" do
     it "accepts values with currencies" do
-      money = YAML.load("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: USD\n")
+      money = yaml_load("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: USD\n")
       expect(money).to eq(Money.new(750, 'usd'))
     end
 
     it "accepts values with null currencies" do
-      money = YAML.load("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: XXX\n")
+      money = yaml_load("--- !ruby/object:Money\nvalue: '750.0'\ncurrency: XXX\n")
       expect(money).to eq(Money.new(750))
     end
 
     it "accepts serialized NullCurrency objects" do
-      money = YAML.load(<<~EOS)
+      money = yaml_load(<<~EOS)
         ---
         !ruby/object:Money
           currency: !ruby/object:Money::NullCurrency
@@ -887,7 +887,7 @@ RSpec.describe "Money" do
     end
 
     it "accepts BigDecimal values" do
-      money = YAML.load(<<~EOS)
+      money = yaml_load(<<~EOS)
         ---
         !ruby/object:Money
           value: !ruby/object:BigDecimal 18:0.75E3
@@ -898,7 +898,7 @@ RSpec.describe "Money" do
     end
 
     it "accepts old float values..." do
-      money = YAML.load(<<~EOS)
+      money = yaml_load(<<~EOS)
         ---
         !ruby/object:Money
           value: 750.00

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,3 +83,9 @@ def configure(default_currency: nil, legacy_json_format: nil, legacy_deprecation
 ensure
   Money.config = old_config
 end
+
+def yaml_load(yaml)
+  return YAML.load(yaml) if Psych::VERSION < '4.0'
+
+  YAML.safe_load(yaml, permitted_classes: [BigDecimal, Money, Money::Currency, Money::NullCurrency])
+end


### PR DESCRIPTION
In addition to the configuration change, it was necessary to adjust YAML loading in the specs to account for the use of `YAML.safe_load` in Psych 4.0 and up (included in Ruby 3.1).

To do this I introduced a wrapper function that explicitly permits deserialization of the Money related classes used in the specs.

This runs green on my fork.