### PR TITLE
Match `to_fs`/`to_formatted_s`/`to_s` aliasing in Active Support

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -242,6 +242,7 @@ class Money
     end
   end
   alias_method :to_s, :to_formatted_s
+  alias_method :to_fs, :to_formatted_s
 
   def to_json(options = nil)
     if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -222,7 +222,7 @@ class Money
     value
   end
 
-  def to_formatted_s(style = nil)
+  def to_fs(style = nil)
     units = case style
     when :legacy_dollars
       2
@@ -241,8 +241,8 @@ class Money
       sprintf("%s%d.%0#{units}d", sign, rounded_value.truncate, rounded_value.frac * (10 ** units))
     end
   end
-  alias_method :to_s, :to_formatted_s
-  alias_method :to_fs, :to_formatted_s
+  alias_method :to_s, :to_fs
+  alias_method :to_formatted_s, :to_fs
 
   def to_json(options = nil)
     if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe "Money" do
     expect{ money.to_formatted_s(:some_weird_style) }.to raise_error(ArgumentError)
   end
 
+  it "to_formatted_s is aliased as to_s for backward compatibility" do
+    expect(money.method(:to_s)).to eq(money.method(:to_formatted_s))
+  end
+
   it "legacy_json_format makes as_json return the legacy format" do
     configure(legacy_json_format: true) do
       expect(Money.new(1, 'CAD').as_json).to eq("1.00")

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe "Money" do
     expect(non_fractional_money.to_s).to eq("1")
   end
 
-  it "to_formatted_s with a legacy_dollars style" do
-    expect(amount_money.to_formatted_s(:legacy_dollars)).to eq("1.23")
-    expect(non_fractional_money.to_formatted_s(:legacy_dollars)).to eq("1.00")
+  it "to_fs with a legacy_dollars style" do
+    expect(amount_money.to_fs(:legacy_dollars)).to eq("1.23")
+    expect(non_fractional_money.to_fs(:legacy_dollars)).to eq("1.00")
   end
 
-  it "to_formatted_s with a amount style" do
-    expect(amount_money.to_formatted_s(:amount)).to eq("1.23")
-    expect(non_fractional_money.to_formatted_s(:amount)).to eq("1")
+  it "to_fs with a amount style" do
+    expect(amount_money.to_fs(:amount)).to eq("1.23")
+    expect(non_fractional_money.to_fs(:amount)).to eq("1")
   end
 
   it "to_s correctly displays negative numbers" do
@@ -104,16 +104,16 @@ RSpec.describe "Money" do
     expect(Money.new("999999999999999999.99", "USD").to_s).to eq("999999999999999999.99")
   end
 
-  it "to_formatted_s raises ArgumentError on unsupported style" do
-    expect{ money.to_formatted_s(:some_weird_style) }.to raise_error(ArgumentError)
+  it "to_fs raises ArgumentError on unsupported style" do
+    expect{ money.to_fs(:some_weird_style) }.to raise_error(ArgumentError)
   end
 
-  it "to_formatted_s is aliased as to_s for backward compatibility" do
-    expect(money.method(:to_s)).to eq(money.method(:to_formatted_s))
+  it "to_fs is aliased as to_s for backward compatibility" do
+    expect(money.method(:to_s)).to eq(money.method(:to_fs))
   end
 
-  it "to_formatted_s is aliased as to_fs for forward compatibility" do
-    expect(money.method(:to_fs)).to eq(money.method(:to_formatted_s))
+  it "to_fs is aliased as to_formatted_s for backward compatibility" do
+    expect(money.method(:to_formatted_s)).to eq(money.method(:to_fs))
   end
 
   it "legacy_json_format makes as_json return the legacy format" do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe "Money" do
     expect(money.method(:to_s)).to eq(money.method(:to_formatted_s))
   end
 
+  it "to_formatted_s is aliased as to_fs for forward compatibility" do
+    expect(money.method(:to_fs)).to eq(money.method(:to_formatted_s))
+  end
+
   it "legacy_json_format makes as_json return the legacy format" do
     configure(legacy_json_format: true) do
       expect(Money.new(1, 'CAD').as_json).to eq("1.00")


### PR DESCRIPTION
#241 added `to_formatted_s` to match Active Support, but it has since changed to `to_fs`. Following the same justification

> having the same interface makes it easier for polymorphic callsites

this adds `to_fs` and defines `to_formatted_s` and `to_s` as aliases for it to continue to match Active Support.