### PR TITLE
Use BigDecimal#zero?

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -124,14 +124,14 @@ class Money
 
   def +(other)
     arithmetic(other) do |money|
-      return self if money.value == 0 && !no_currency?
+      return self if money.value.zero? && !no_currency?
       Money.new(value + money.value, calculated_currency(money.currency))
     end
   end
 
   def -(other)
     arithmetic(other) do |money|
-      return self if money.value == 0 && !no_currency?
+      return self if money.value.zero? && !no_currency?
       Money.new(value - money.value, calculated_currency(money.currency))
     end
   end


### PR DESCRIPTION
This PR does not change behavior but improves performance slightly, as `#zero?` is faster than `== 0`. We made a similar optimization [in this PR](https://github.com/Shopify/money/pull/126).

I noticed these calls to `BigDecimal#==` on a performance profile and also on a memory profile for an API endpoint I was profiling.