### PR TITLE
Remove Postgres money type recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Money::Currency.new("MGA").minor_units  # => 1
 ## Money column
 
 Since money internally uses BigDecimal it's logical to use a `decimal` column
-(or `money` for PostgreSQL) for your database. The `money_column` method can
-generate methods for use with ActiveRecord:
+for your database. The `money_column` method can generate methods for use with
+ActiveRecord:
 
 ```ruby
 create_table :orders do |t|


### PR DESCRIPTION
The money type causes issues with amounts setting to 0 after saving. This is because a string is returned, not a BigDecimal, and these values don't play well with the [`value_to_decimal`](https://github.com/Shopify/money/blob/019954286ba8909e96e134ccef0f76b659a68450/lib/money/helpers.rb#L15) helper used throughout:
```ruby
account.balance_before_type_cast
=> "$100.00"
BigDecimal(account.balance_before_type_cast, exception: false)
=> nil
```