### PR TITLE
Stringify money BigDecimal value in Active Job serializer

### DIFF
--- a/lib/money/rails/job_argument_serializer.rb
+++ b/lib/money/rails/job_argument_serializer.rb
@@ -4,7 +4,7 @@ class Money
   module Rails
     class JobArgumentSerializer < ::ActiveJob::Serializers::ObjectSerializer
       def serialize(money)
-        super("value" => money.value, "currency" => money.currency.iso_code)
+        super("value" => money.value.to_s("F"), "currency" => money.currency.iso_code)
       end
 
       def deserialize(hash)

--- a/spec/rails/job_argument_serializer_spec.rb
+++ b/spec/rails/job_argument_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Money::Rails::JobArgumentSerializer do
     serialized_job = job.serialize
     serialized_value = serialized_job["arguments"][0]["value"]
     expect(serialized_value["_aj_serialized"]).to eq("Money::Rails::JobArgumentSerializer")
-    expect(serialized_value["value"]).to eq(BigDecimal("10.21"))
+    expect(serialized_value["value"]).to eq("10.21")
     expect(serialized_value["currency"]).to eq("BRL")
 
     job2 = MoneyTestJob.deserialize(serialized_job)


### PR DESCRIPTION
Sidekiq 7.0 by default enforces that values must be JSON safe: https://github.com/mperham/sidekiq/blob/v7.0.0/lib/sidekiq/job_util.rb#L68 (see https://github.com/mperham/sidekiq/pull/5071) i.e. before and after a serialization roundtrip be exactly the same.

Before this fix ActiveJob enqueues a BigDecimal, which eventually does end up in the same string representation thanks to Active Support's extension: https://guides.rubyonrails.org/v7.0.0/active_support_core_extensions.html#extensions-to-bigdecimal with thix fix we do the same explicitly to make Sidekiq happy.

Since Money can handle well-formed string values there are no forwards or backwards compatibility problems.