### PR TITLE
Serialise `value` as a String instead of remaining as BigDecimal

### DIFF
--- a/lib/money/rails/job_argument_serializer.rb
+++ b/lib/money/rails/job_argument_serializer.rb
@@ -4,7 +4,7 @@ class Money
   module Rails
     class JobArgumentSerializer < ::ActiveJob::Serializers::ObjectSerializer
       def serialize(money)
-        super("value" => money.value, "currency" => money.currency.iso_code)
+        super("value" => money.value.to_s, "currency" => money.currency.iso_code)
       end
 
       def deserialize(hash)

--- a/spec/rails/job_argument_serializer_spec.rb
+++ b/spec/rails/job_argument_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Money::Rails::JobArgumentSerializer do
     serialized_job = job.serialize
     serialized_value = serialized_job["arguments"][0]["value"]
     expect(serialized_value["_aj_serialized"]).to eq("Money::Rails::JobArgumentSerializer")
-    expect(serialized_value["value"]).to eq(BigDecimal("10.21"))
+    expect(serialized_value["value"]).to eq("10.21")
     expect(serialized_value["currency"]).to eq("BRL")
 
     job2 = MoneyTestJob.deserialize(serialized_job)


### PR DESCRIPTION
Sidekiq 7 now raises an error when job arguments can't be safely serialised to JSON-friendly types.
The current implementation of JobArgumentSerializer serialises `Money.value` to a BigDecimal type, which is not JSON-friendly.

<details>
<summary>An example of the error</summary>

```
Failed enqueuing MyRealJob to Sidekiq(default): ArgumentError (Job arguments to MyRealJob must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.
To disable this error, add `Sidekiq.strict_args!(false)` to your initializer.
)
```
</details>

We would prefer to keep it the argument checking set to strict and instead serialise `Money.value` to something else (e.g. String).

This is something that other folks will also run into if they are also passing `Money` objects as job arguments.