### PR TITLE
Allow splat arg in `Money/MissingCurrency` cop

### DIFF
--- a/lib/rubocop/cop/money/missing_currency.rb
+++ b/lib/rubocop/cop/money/missing_currency.rb
@@ -32,7 +32,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          money_new(node) do |_amount, currency_arg|
+          money_new(node) do |amount, currency_arg|
+            return if amount&.splat_type?
             return if currency_arg
 
             add_offense(node, message: 'Money is missing currency argument')

--- a/spec/rubocop/cop/money/missing_currency_spec.rb
+++ b/spec/rubocop/cop/money/missing_currency_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe RuboCop::Cop::Money::MissingCurrency do
       RUBY
     end
 
+    it 'does not register an offense for Money.new with splat argument' do
+      expect_no_offenses(<<~RUBY)
+        value_and_currency = [1, 'CAD']
+        Money.new(*value_and_currency)
+      RUBY
+    end
+
     it 'registers an offense and corrects for Money.new without a currency argument' do
       expect_offense(<<~RUBY)
         Money.new


### PR DESCRIPTION
This stops the `Money/MissingCurrency` cop from considering the following an offense:

```diff
 value_and_currency = [1, 'CAD']
 Money.new(*value_and_currency)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Money is missing currency argument
```

It is unlikely that someone would use a splat without knowing it contains both an amount and currency, so we should allow it.