### PR TITLE
Use Ruby 3.2 in dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     name: Ruby ${{ matrix.ruby }}
     steps:

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@
 ---
 name: money
 up:
-- ruby: 2.6.6
+- ruby: 3.2.0
 - bundler
 commands:
   test: bundle exec rspec


### PR DESCRIPTION
2.6's end-of-life was on March 31 2022, and we no longer use a pre-built binary for it in development. Moreover, building from source doesn't seem to work, so rather than troubleshoot that, we can just jump to a recent Ruby, and rely on CI for old ones.