### PR TITLE
Stripe requires 2 decimals for UGX currency

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -10,6 +10,7 @@ class Money
 
     STRIPE_SUBUNIT_OVERRIDE = {
       'ISK' => 100,
+      'UGX' => 100,
     }.freeze
 
     def value_to_decimal(num)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -376,6 +376,10 @@ RSpec.describe "Money" do
         expect(Money.from_subunits(100, 'ISK', format: :stripe)).to eq(Money.new(1, 'ISK'))
       end
 
+      it 'overrides the subunit_to_unit amount for UGX' do
+        expect(Money.from_subunits(100, 'UGX', format: :stripe)).to eq(Money.new(1, 'UGX'))
+      end
+
       it 'fallbacks to the default subunit_to_unit amount if no override is specified' do
         expect(Money.from_subunits(100, 'USD', format: :stripe)).to eq(Money.new(1, 'USD'))
       end
@@ -620,6 +624,10 @@ RSpec.describe "Money" do
     describe 'with format specified' do
       it 'overrides the subunit_to_unit amount' do
         expect(Money.new(1, 'ISK').subunits(format: :stripe)).to eq(100)
+      end
+
+      it 'overrides the subunit_to_unit amount for UGX' do
+        expect(Money.new(1, 'UGX').subunits(format: :stripe)).to eq(100)
       end
 
       it 'fallbacks to the default subunit_to_unit amount if no override is specified' do


### PR DESCRIPTION
`UGX` currency has 0 decimals as per the ISO 4217 standard (see the [official currency decimals list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency))

However, for backward compatibility, Stripe requires `UGX` currency amounts with 2 decimals:  https://stripe.com/docs/currencies#special-cases.

With this change, `5 UGX` would be converted to `500` when using the `:stripe` format:
```ruby
  Money.new(5, 'UGX').subunits(format: :stripe) == 500
```