### PR TITLE
Add missing require for Rubocop rule

### DIFF
--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Money
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/lib/rubocop/cop/money.rb
+++ b/lib/rubocop/cop/money.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require 'rubocop/cop/money/missing_currency'
+require 'rubocop/cop/money/unsafe_to_money'
 require 'rubocop/cop/money/zero_money'


### PR DESCRIPTION
Rule introduced in #264 

Otherwise, include the gem doesn't expose the rule:
```
$ bin/rubocop --only Money/UnsafeToMoney
Error: unrecognized cop or department Money/UnsafeToMoney found in .rubocop.yml
Did you mean `Money/ZeroMoney`?
```