### PR TITLE
update `to_money` to have the same behaviour as `Money.new`

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -14,6 +14,11 @@ end
 #   '100.37'.to_money => #<Money @cents=10037>
 class String
   def to_money(currency = nil)
-    Money::Parser::Fuzzy.parse(self, currency)
+    if Money.config.legacy_deprecations
+      Money.deprecate("`#{self}.to_money` will raise an ArgumentError in the next major release")
+      Money::Parser::Fuzzy.parse(self, currency)
+    else
+      Money.new(self, currency)
+    end
   end
 end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -43,8 +43,15 @@ RSpec.describe String do
   it_should_behave_like "an object supporting to_money"
 
   it "parses an empty string to Money.zero" do
-    expect(''.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
-    expect(' '.to_money).to eq(Money.new(0, Money::NULL_CURRENCY))
+    configure(legacy_deprecations: true) do
+      expect(Money).to receive(:deprecate).twice
+      expect("".to_money("USD")).to eq(Money.new(0, "USD"))
+      expect(" ".to_money("CAD")).to eq(Money.new(0, "CAD"))
+    end
+  end
+
+  it "#to_money should behave like Money.new with three decimal places amounts" do
+    expect("29.000".to_money("USD")).to eq(Money.new("29.000", "USD"))
   end
 end
 


### PR DESCRIPTION
# Why

To avoid gotchas, `string.to_money("USD")` should behave exactly the same as `Money.new(string, "USD")`
Also the deprecation warning will help us search the logs to know how often and who is using the method incorrectly

# What
Make the change but keep the old behaviour under the `legacy_deprecations` option... until we're confident we can remove it. For those with that legacy support, they can rely on the newly added rubocop rule to help them migrate away from the old `.to_money`