### PR TITLE
Fix UnsafeToMoney for receiver-less calls

### DIFF
--- a/lib/rubocop/cop/money/unsafe_to_money.rb
+++ b/lib/rubocop/cop/money/unsafe_to_money.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.method?(:to_money)
-          return if node.receiver.is_a?(AST::NumericNode)
+          return if node.receiver.nil? || node.receiver.is_a?(AST::NumericNode)
 
           add_offense(node, location: :selector)
         end

--- a/spec/rubocop/cop/money/unsafe_to_money_spec.rb
+++ b/spec/rubocop/cop/money/unsafe_to_money_spec.rb
@@ -53,5 +53,11 @@ RSpec.describe RuboCop::Cop::Money::UnsafeToMoney do
         Money.new(obj.money, 'USD')
       RUBY
     end
+
+    it 'does not register an offense for receiver-less calls' do
+      expect_no_offenses(<<~RUBY)
+        a = to_money
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
The cop used to match on "receiver-less" calls, and crash when trying to use the autocorrect logic.

The error was:

```
RuboCop::ErrorWithAnalyzedFileLocation:
  cause: #<NoMethodError: undefined method `source' for nil:NilClass>
```

Coming from [this line][1]

---

I decided to not flag these calls, in my example it was a private method called `to_money`, and was therefore not an offense that the cop tries to catch.

---

[1]:https://github.com/Shopify/money/blob/b35448a60c65da08df73f700447b76d3360027b4/lib/rubocop/cop/money/unsafe_to_money.rb#L26