### PR TITLE
improve deprecation message for to_money

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -15,8 +15,10 @@ end
 class String
   def to_money(currency = nil)
     if Money.config.legacy_deprecations
-      Money.deprecate("`#{self}.to_money` will raise an ArgumentError in the next major release")
-      Money::Parser::Fuzzy.parse(self, currency)
+      Money::Parser::Fuzzy.parse(self, currency).tap do |money|
+        message = "`#{self}.to_money` will raise an ArgumentError in the next major release. Use `Money.new` instead."
+        Money.deprecate(message) if money != Money.new(self, currency)
+      end
     else
       Money.new(self, currency)
     end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -43,15 +43,26 @@ RSpec.describe String do
   it_should_behave_like "an object supporting to_money"
 
   it "parses an empty string to Money.zero" do
+    expect("".to_money("USD")).to eq(Money.new(0, "USD"))
+
     configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate).twice
-      expect("".to_money("USD")).to eq(Money.new(0, "USD"))
+      expect(Money).to receive(:deprecate).once
       expect(" ".to_money("CAD")).to eq(Money.new(0, "CAD"))
     end
   end
 
+  it "#to_money to handle thousands delimiters" do
+    configure(legacy_deprecations: true) do
+      expect(Money).to receive(:deprecate).at_least(4).times
+      expect("29.000".to_money("USD")).to eq(Money.new("29000", "USD"))
+      expect("29.000,00".to_money("USD")).to eq(Money.new("29000", "USD"))
+      expect("29,000".to_money("USD")).to eq(Money.new("29000", "USD"))
+      expect("29,000.00".to_money("USD")).to eq(Money.new("29000", "USD"))
+    end
+  end
+
   it "#to_money should behave like Money.new with three decimal places amounts" do
-    expect("29.000".to_money("USD")).to eq(Money.new("29.000", "USD"))
+    expect("29.000".to_money("USD")).to eq(Money.new("29.00", "USD"))
   end
 end
 


### PR DESCRIPTION
improve the language to explain that we expect folks to use `Money.new` instead of `to_money`