### PR TITLE
avoid duplicate deprecations

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -16,8 +16,9 @@ class String
   def to_money(currency = nil)
     if Money.config.legacy_deprecations
       Money::Parser::Fuzzy.parse(self, currency).tap do |money|
-        message = "`#{self}.to_money` will raise an ArgumentError in the next major release. Use `Money.new` instead."
-        Money.deprecate(message) if money != Money.new(self, currency)
+        message = "`#{self}.to_money` will behave like `Money.new` and raise on the next release. " \
+          "To parse user input, do so on the browser and use the user's locale."
+        Money.deprecate(message) if money.value != BigDecimal(self, exception: false)
       end
     else
       Money.new(self, currency)

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe String do
 
   it "#to_money to handle thousands delimiters" do
     configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate).at_least(4).times
+      expect(Money).to receive(:deprecate).exactly(4).times
       expect("29.000".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29.000,00".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29,000".to_money("USD")).to eq(Money.new("29000", "USD"))


### PR DESCRIPTION
# Why

Prevent double deprecation warning, and improve the deprecation wording explain what will really happen in the next release

before this change we'd get two deprecation warnings for strings with delimiters, ex: `"1,234".to_money("USD")`
- deprecation for `"1,234".to_money`
- deprecation for `Money.new("1,234")`

Note: this boolean makes the deprecation warnings less noisy for folks that would already get the same behaviour from `to_money` since they are not using strings with thousand delimiters

# What

This PR make use of BigDecimal directly to avoid this problem when checking the value
