### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Money
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Release Notes:
- Allow splat arg in Money/MissingCurrency cop [Sam Bostock]
- Fix UnsafeToMoney for receiver-less calls [Pierre Jambet]
- [BREAKING] update `to_money` to have the same behaviour as `Money.new` [Michael Elfassy]

note: the breaking change only affects users that are using `to_money` to parse strings with thousands separators (ex: "1,234") and do not use the `legacy_deprecations` configuration. For those affected, they can choose to revert to the old behaviour by using `Money::Parser::Fuzzy.parse` instead of `to_money`

https://github.com/Shopify/money/compare/v1.2.1...prepare-1.3.0