### PR TITLE
Better error if `Money#allocate` called with an empty array

### DIFF
--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -42,6 +42,10 @@ class Money
     #   Money.new(10.01, "USD").allocate([0.5, 0.5], :roundrobin_reverse)
     #     #=> [#<Money value:5.00 currency:USD>, #<Money value:5.01 currency:USD>]
     def allocate(splits, strategy = :roundrobin)
+      if splits.empty?
+        raise ArgumentError, 'at least one split must be provided'
+      end
+
       splits.map!(&:to_r)
       allocations = splits.inject(0, :+)
 

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "Allocator" do
       expect { new_allocator(0.05).allocate([0.5,0.6]) }.to raise_error(ArgumentError)
     end
 
+    specify "#allocate requires at least one split" do
+      expect { new_allocator(0.05).allocate([]) }.to raise_error(ArgumentError)
+    end
+
     specify "#allocate will use rationals if provided" do
       splits = [128400,20439,14589,14589,25936].map{ |num| Rational(num, 203953) } # sums to > 1 if converted to float
       expect(new_allocator(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])


### PR DESCRIPTION
At the moment if you do `Money.new(1, "USD").allocate([])` it will raise with:

```
lib/money/allocator.rb:138:in `%': divided by 0 (ZeroDivisionError)
```

Since this is an invalid input, it's better to identify that and raise earlier with a more clear message.