### PR TITLE
require ruby 3.0+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: tests
 
 on: [push, pull_request]
-  
+
 jobs:
   build:
 
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
 
     name: Ruby ${{ matrix.ruby }}
     steps:

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@
 ---
 name: money
 up:
-- ruby: 3.2.0
+- ruby: 3.3.0
 - bundler
 commands:
   test: bundle exec rspec

--- a/money.gemspec
+++ b/money.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("database_cleaner", "~> 1.6")
   s.add_development_dependency("sqlite3", "~> 1.4.2")
 
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.0'
 
   s.files = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Ruby 3 has been release for 3 years. Support for ruby 2.x is no longer required and causes issues with bundler