### PR TITLE
improve the wording of the to_money deprecations warning

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -10,6 +10,30 @@ class Money
   attr_reader :value, :currency
   def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
 
+  class ReverseOperationProxy
+    include Comparable
+
+    def initialize(value)
+      @value = value
+    end
+
+    def <=>(other)
+      -(other <=> @value)
+    end
+
+    def +(other)
+      other + @value
+    end
+
+    def -(other)
+      -(other - @value)
+    end
+
+    def *(other)
+      other * @value
+    end
+  end
+
   class << self
     extend Forwardable
     attr_accessor :config
@@ -160,30 +184,6 @@ class Money
     return false unless other.is_a?(Money)
     return false unless currency.compatible?(other.currency)
     value == other.value
-  end
-
-  class ReverseOperationProxy
-    include Comparable
-
-    def initialize(value)
-      @value = value
-    end
-
-    def <=>(other)
-      -(other <=> @value)
-    end
-
-    def +(other)
-      other + @value
-    end
-
-    def -(other)
-      -(other - @value)
-    end
-
-    def *(other)
-      other * @value
-    end
   end
 
   def coerce(other)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -30,15 +30,20 @@ RSpec.describe "Money" do
 
   it "returns itself with to_money" do
     expect(money.to_money).to eq(money)
+    expect(amount_money.to_money).to eq(amount_money)
   end
 
   it "#to_money uses the provided currency when it doesn't already have one" do
     expect(Money.new(1).to_money('CAD')).to eq(Money.new(1, 'CAD'))
   end
 
+  it "#to_money works with money objects of the same currency" do
+    expect(Money.new(1, 'CAD').to_money('CAD')).to eq(Money.new(1, 'CAD'))
+  end
+
   it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
     configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate).once
+      expect(Money).to receive(:deprecate).with(match(/to_money is attempting to change currency of an existing money object/)).once
       expect(Money.new(1, 'USD').to_money('CAD')).to eq(Money.new(1, 'USD'))
     end
   end
@@ -192,7 +197,7 @@ RSpec.describe "Money" do
 
   it "logs a deprecation warning when adding across currencies" do
     configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate)
+      expect(Money).to receive(:deprecate).with(match(/mathematical operation not permitted for Money objects with different currencies/))
       expect(Money.new(10, 'USD') - Money.new(1, 'JPY')).to eq(Money.new(9, 'USD'))
     end
   end


### PR DESCRIPTION
## Why

We want to track deprecations happening with the `.to_money` method seperatly from those from arithmetic computations. This will allow us to safely raise knowing these issues no longer happen in production

## What

Introduce a new deprecation warning message for `to_money` with inconsistent currencies

Before:
```
Money.new(1, "USD").to_money("CAD") 
# "mathematical operation not permitted for Money objects with different currencies CAD and USD. A Money::IncompatibleCurrencyError will raise in the next major release"
```

After:
```
Money.new(1, "USD").to_money("CAD") 
# "to_money is attempting to change currency of an existing money object from USD to CAD. A Money::IncompatibleCurrencyError will raise in the next major release"
```

## Note

This only affects those using the `legacy_deprecations` option. Others will continue to get an `Money::IncompatibleCurrencyError` exception

@Shopify/shopify-money 