### PR TITLE
handle null currency money objects passed to constructor

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -106,7 +106,15 @@ class Money
     private
 
     def new_from_money(amount, currency)
-      return amount if amount.currency.compatible?(Helpers.value_to_currency(currency))
+      currency = Helpers.value_to_currency(currency)
+
+      if amount.no_currency?
+        return Money.new(amount.value, currency)
+      end
+
+      if amount.currency.compatible?(currency)
+        return amount
+      end
 
       msg = "Money.new is attempting to change currency of an existing money object"
       if Money.config.legacy_deprecations

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe "Money" do
     expect(Money.new(1, 'CAD').to_money('CAD')).to eq(Money.new(1, 'CAD'))
   end
 
+  it "#to_money works with money objects that doesn't have a currency" do
+    money = Money.new(1, Money::NULL_CURRENCY).to_money('USD')
+    expect(money.value).to eq(1)
+    expect(money.currency.to_s).to eq('USD')
+
+    money = Money.new(1, 'USD').to_money(Money::NULL_CURRENCY)
+    expect(money.value).to eq(1)
+    expect(money.currency.to_s).to eq('USD')
+  end
+
   it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
     configure(legacy_deprecations: true) do
       expect(Money).to receive(:deprecate).with(match(/to_money is attempting to change currency of an existing money object/)).once
@@ -70,6 +80,17 @@ RSpec.describe "Money" do
 
   it "can be constructed with a money object" do
     expect(Money.new(Money.new(1))).to eq(Money.new(1))
+    expect(Money.new(Money.new(1, "USD"), "USD")).to eq(Money.new(1, "USD"))
+  end
+
+  it "can be constructed with a money object with a null currency" do
+    money = Money.new(Money.new(1, Money::NULL_CURRENCY), 'USD')
+    expect(money.value).to eq(1)
+    expect(money.currency.to_s).to eq('USD')
+
+    money = Money.new(Money.new(1, 'USD'), Money::NULL_CURRENCY)
+    expect(money.value).to eq(1)
+    expect(money.currency.to_s).to eq('USD')
   end
 
   it "constructor raises when changing currency" do


### PR DESCRIPTION
# Why
https://github.com/Shopify/money/pull/289 introduced a bug in the way NullCurrency is handled

Bad
```ruby
> Money.new(Money.new(1, Money::NULL_CURRENCY), "USD")
#<Money value:1.00 currency:>
```

Good
```ruby
> Money.new(Money.new(1, Money::NULL_CURRENCY), "USD")
#<Money value:1.00 currency:"USD">
```

# What

Add regression tests and handle this edge case