### PR TITLE
re-allow coercing strings to money objects

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -371,7 +371,7 @@ class Money
       end
       yield(money_or_numeric)
 
-    when Numeric
+    when Numeric, String
       yield(Money.new(money_or_numeric, currency))
 
     else

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -556,13 +556,19 @@ RSpec.describe "Money" do
         it { expect(cad_10 == usd_10).to(eq(false)) }
       end
 
-      describe('to_money types') do
+      describe('to_money coerced types') do
         it { expect(cad_10 <=> 10.00).to(eq(0)) }
         it { expect(cad_10 >   10.00).to(eq(false)) }
         it { expect(cad_10 >=  10.00).to(eq(true)) }
         it { expect(cad_10 ==  10.00).to(eq(false)) }
         it { expect(cad_10 <=  10.00).to(eq(true)) }
         it { expect(cad_10 <   10.00).to(eq(false)) }
+        it { expect(cad_10 <=>'10.00').to(eq(0)) }
+        it { expect(cad_10 >  '10.00').to(eq(false)) }
+        it { expect(cad_10 >= '10.00').to(eq(true)) }
+        it { expect(cad_10 == '10.00').to(eq(false)) }
+        it { expect(cad_10 <= '10.00').to(eq(true)) }
+        it { expect(cad_10 <  '10.00').to(eq(false)) }
       end
     end
 


### PR DESCRIPTION
# Why

https://github.com/Shopify/money/pull/283 introduced a regression that was un-intended

Previously coercing strings was supported, even if not explicitly tested:

```ruby
Money.new(1) > "2.00"

# was the same as
# Money.new(1) > "2.00".to_money
```

We should not be deprecating behaviour without proper deprecation warning

# What

Revert this behaviour and bring back support for String coercing. Added test to make this behaviour explicit.

As a follow up, we should decide if we want to deprecated this behaviour in a future release