### PR TITLE
bump to v2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (2.2.0)
+    shopify-money (2.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Money
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
## What's Changed
* remove the `Money/UnsafeToMoney` cop by @elfassy in https://github.com/Shopify/money/pull/291
* Add release instructions by @sambostock in https://github.com/Shopify/money/pull/259
* handle null currency money objects passed to constructor by @elfassy in https://github.com/Shopify/money/pull/292
* re-allow coercing strings to money objects by @elfassy in https://github.com/Shopify/money/pull/293
* Remove reference to deleted file by @mkorostoff-shopify in https://github.com/Shopify/money/pull/295
* support coercible objects that respond to `to_money` by @elfassy in https://github.com/Shopify/money/pull/294


**Full Changelog**: https://github.com/Shopify/money/compare/v2.2.0...v2.2.1

# Note

The previous version bump (v2.2.0) introduced an undocumented breaking change. Making this change visible here:

```ruby
# before v2.2.0
Money.new(Money.new(1, "USD"), Money::NULL_CURRENCY)
#=> Money.new(1, Money::NULL_CURRENCY)

# after v2.2.0
Money.new(Money.new(1, "USD"), Money::NULL_CURRENCY)
#=> Money.new(1, "USD")

# to get the old behaviour of ignoring the currency, explicitly pass only the value
Money.new(Money.new(1, "USD").value, Money::NULL_CURRENCY)
```

