### PR TITLE
improve deprecation warning messages

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -14,14 +14,23 @@ end
 #   '100.37'.to_money => #<Money @cents=10037>
 class String
   def to_money(currency = nil)
-    if Money.config.legacy_deprecations
-      Money::Parser::Fuzzy.parse(self, currency).tap do |money|
-        message = "`#{self}.to_money` will behave like `Money.new` and raise on the next release. " \
-          "To parse user input, do so on the browser and use the user's locale."
-        Money.deprecate(message) if money.value != BigDecimal(self, exception: false)
+    return Money.new(self, currency) unless Money.config.legacy_deprecations
+
+    Money::Parser::Fuzzy.parse(self, currency).tap do |money|
+      new_value = BigDecimal(self, exception: false)
+      old_value = money.value
+
+      if new_value != old_value
+        message = "`\"#{self}\".to_money` will soon behave like `Money.new(\"#{self}\")` and "
+        message +=
+          if new_value.nil?
+            "raise an ArgumentError exception."
+          else
+            "return #{new_value} instead of #{old_value}."
+          end
+        message += " Best practice to parse user input is to do so on the browser and use the user's locale."
+        Money.deprecate(message)
       end
-    else
-      Money.new(self, currency)
     end
   end
 end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -116,7 +116,7 @@ class Money
         return amount
       end
 
-      msg = "Money.new is attempting to change currency of an existing money object"
+      msg = "Money.new(Money.new(amount, #{amount.currency}), #{currency}) is changing the currency of an existing money object"
       if Money.config.legacy_deprecations
         Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
         return Money.new(amount.value, currency)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Money" do
 
   it "legacy_deprecations constructor with money used the constructor currency" do
     configure(legacy_deprecations: true) do
-     expect(Money).to receive(:deprecate).with(match(/Money.new is attempting to change currency of an existing money object/)).once
+     expect(Money).to receive(:deprecate).with(match(/Money.new\(Money.new\(amount, USD\), CAD\) is changing the currency of an existing money object/)).once
       expect(Money.new(Money.new(1, 'USD'), 'CAD')).to eq(Money.new(1, 'CAD'))
     end
   end


### PR DESCRIPTION
# Why

Deprecations were hard to understand

# What

Improve the wording to make it explicit what needs to be fixed