### PR TITLE
don't show deprecation if the to_money result is the same as Money.new

### DIFF
--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe String do
     end
   end
 
+  it "#to_money does not warn when it already behaves like Money.new" do
+  configure(legacy_deprecations: true) do
+    expect(Money).to receive(:deprecate).never
+    expect("71.94999999999999".to_money("USD")).to eq(Money.new("71.95", "USD"))
+    expect("0.001".to_money("USD")).to eq(Money.new("0", "USD"))
+  end
+end
+
   it "#to_money should behave like Money.new with three decimal places amounts" do
     expect("29.000".to_money("USD")).to eq(Money.new("29.00", "USD"))
   end


### PR DESCRIPTION
# Why

we were showing deprecation warnings even if to_money would generate the same output as Money.new
For example:
```
"71.94999999999999".to_money("USD") == Money.new("71.95", "USD")
```
 

# What

take into account rounding