### PR TITLE
remove legacy thousand fuzzy parsing

### DIFF
--- a/lib/money/parser/fuzzy.rb
+++ b/lib/money/parser/fuzzy.rb
@@ -161,11 +161,6 @@ class Money
           return true
         end
 
-        # legacy support for 1.000 USD
-        if digits.last.size == 3 && digits.first.size <= 3 && currency.minor_units < 3
-          return false
-        end
-
         # The last mark matches the one used by the provided currency to delimiter decimals
         currency.decimal_mark == last_mark
       end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe String do
   it "#to_money to handle thousands delimiters" do
     configure(legacy_deprecations: true) do
       expect(Money).to receive(:deprecate).exactly(4).times
-      expect("29.000".to_money("USD")).to eq(Money.new("29000", "USD"))
+      expect("29.000".to_money("EUR")).to eq(Money.new("29000", "EUR"))
       expect("29.000,00".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29,000".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29,000.00".to_money("USD")).to eq(Money.new("29000", "USD"))

--- a/spec/parser/accounting_spec.rb
+++ b/spec/parser/accounting_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Money::Parser::Accounting do
 
     it "parses thousands amount" do
       Money.with_currency(Money::NULL_CURRENCY) do
-        expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+        expect(@parser.parse("1.000")).to eq(Money.new(1.00))
       end
     end
 

--- a/spec/parser/fuzzy_spec.rb
+++ b/spec/parser/fuzzy_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses no currency amount" do
-      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1000, Money::NULL_CURRENCY))
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1, Money::NULL_CURRENCY))
     end
 
     it "parses amount with more than 3 decimals correctly" do
@@ -255,7 +255,7 @@ RSpec.describe Money::Parser::Fuzzy do
   describe "no decimal currency" do
     it "parses thousands correctly" do
       expect(@parser.parse("1,111", "JPY")).to eq(Money.new(1_111, 'JPY'))
-      expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+      expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1, 'JPY'))
       expect(@parser.parse("1 111", "JPY")).to eq(Money.new(1_111, 'JPY'))
       expect(@parser.parse("1111,111", "JPY")).to eq(Money.new(1_111_111, 'JPY'))
     end
@@ -270,7 +270,7 @@ RSpec.describe Money::Parser::Fuzzy do
   describe "two decimal currency" do
     it "parses thousands correctly" do
       expect(@parser.parse("1,111", "USD")).to eq(Money.new(1_111, 'USD'))
-      expect(@parser.parse("1.111", "USD")).to eq(Money.new(1_111, 'USD'))
+      expect(@parser.parse("1.111", "EUR")).to eq(Money.new(1_111, 'EUR'))
       expect(@parser.parse("1 111", "USD")).to eq(Money.new(1_111, 'USD'))
       expect(@parser.parse("1111,111", "USD")).to eq(Money.new(1_111_111, 'USD'))
     end


### PR DESCRIPTION
# Why

For legacy reasons the FuzzyParser would convert `1.000` to `1_000` irregardless of currency. This is no longer required

# What

Apps using this parser will convert `1.000` using the delimiter of the currency

```ruby
Money::Parser::Fuzzy.parse("1.000", "USD") == Money.new(1, "USD")
Money::Parser::Fuzzy.parse("1.000", "EUR") == Money.new(1000, "EUR")
```