### PR TITLE
[NullCurrency] Set minor units to 4

### DIFF
--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -44,8 +44,8 @@ class Money
       @iso_numeric           = '999'
       @name                  = 'No Currency'
       @smallest_denomination = 1
-      @subunit_to_unit       = 100
-      @minor_units           = 2
+      @subunit_to_unit       = 10000
+      @minor_units           = 4
       @decimal_mark          = '.'
       freeze
     end

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -15,12 +15,19 @@ RSpec.describe "NullCurrency" do
 
     it "quacks like USD" do
       expect(null_currency.symbol).to eq('$')
-      expect(null_currency.subunit_to_unit).to eq(100)
       expect(null_currency.smallest_denomination).to eq(1)
     end
 
     it "has the name No Currency" do
       expect(null_currency.name).to eq('No Currency')
+    end
+
+    it "has 10000 subunits to units" do
+      expect(null_currency.subunit_to_unit).to eq(10000)
+    end
+
+    it "has 4 minor units" do
+      expect(null_currency.minor_units).to eq(4)
     end
   end
 

--- a/spec/parser/accounting_spec.rb
+++ b/spec/parser/accounting_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Money::Parser::Accounting do
 
     it "parses thousands amount" do
       Money.with_currency(Money::NULL_CURRENCY) do
-        expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+        expect(@parser.parse("1,000")).to eq(Money.new(1000.0000))
       end
     end
 

--- a/spec/parser/fuzzy_spec.rb
+++ b/spec/parser/fuzzy_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses no currency amount" do
-      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1000, Money::NULL_CURRENCY))
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1.000, Money::NULL_CURRENCY))
     end
 
     it "parses amount with more than 3 decimals correctly" do


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify/issues/511351

## ❓ Why this fix

Our GraphQL scalar `Money` currently rounds all amounts with > 2 decimal places. This causes incorrect refund amount, as described in this comment: https://github.com/Shopify/shopify/issues/511351#issuecomment-2159230147

When money values are rounded incorrectly, our merchants suffer. 

## 💥 Impact of this PR

This will set the default currency to 4 minor units, which means the subunit to unit will be 10000 instead of 100. Are there any breaking features I should be aware of? I'm fairly certain this is considered **breaking** according to [semantic versioning](https://semver.org/). 