### PR TITLE
Remove deprecation notice and raise error when strings cannot be parsed by bigdecimal

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -29,11 +29,7 @@ class Money
         when Rational
           BigDecimal(num, MAX_DECIMAL)
         when String
-          decimal = BigDecimal(num, exception: !Money.config.legacy_deprecations)
-          return decimal if decimal
-
-          Money.deprecate("using Money.new('#{num}') is deprecated and will raise an ArgumentError in the next major release")
-          DECIMAL_ZERO
+          BigDecimal(num)
         else
           raise ArgumentError, "could not parse as decimal #{num.inspect}"
         end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -45,11 +45,8 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_decimal(' -1.23 ')).to eq(-amount)
     end
 
-    it 'invalid string returns zero' do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).once
-        expect(subject.value_to_decimal('invalid')).to eq(0)
-      end
+    it 'invalid string raises error' do
+      expect { subject.value_to_decimal('invalid') }.to raise_error(ArgumentError)
     end
 
     it 'raises on invalid object' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -104,13 +104,6 @@ RSpec.describe "Money" do
     end
   end
 
-  it "legacy_deprecations defaults to 0 when constructed with an invalid string" do
-    configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate).once
-      expect(Money.new('invalid', 'USD')).to eq(Money.new(0.00, 'USD'))
-    end
-  end
-
   it "raises when constructed with an invalid string" do
     expect{ Money.new('invalid') }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
issue: https://github.com/Shopify/money/pull/307

# Why

Currently we attempt to parse strings with BigDecimal, and we default to `BigDecimal(0)` for cases where the string cannot be parsed. In v3, we want to remove this fallback and we recommend users to parse the money first before using initializing a new money object. 

# What

**This is a breaking change**

We now raise ArgumentError if the provided value is a string and cannot be parsed by BigDecimal. 

```ruby
Money.new("$1.00", "USD") # -> raises invalid value for BigDecimal(): "$1.00" (ArgumentError)
```