### PR TITLE
"".to_money does not generate a deprecation warning

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -20,6 +20,8 @@ class String
       return Money.new(self, currency)
     end
 
+    return Money.new(0, currency) if self.empty?
+
     Money::Parser::Fuzzy.parse(self, currency).tap do |money|
       new_value = BigDecimal(self, exception: false)&.round(currency.minor_units)
       old_value = money.value

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe String do
     configure(legacy_deprecations: true) do
       expect(Money).to receive(:deprecate).once
       expect(" ".to_money("CAD")).to eq(Money.new(0, "CAD"))
+
+      # empty should not show a deprecation
+      expect("".to_money("USD")).to eq(Money.new(0, "USD"))
     end
   end
 


### PR DESCRIPTION
# Why

`"".to_money` should behave like `Money.new("")` and not return a deprecation warning


# What

fix the things