### PR TITLE
to_money parse with Money.new when there is no thousand delimiter

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -20,18 +20,18 @@ class String
       return Money.new(self, currency)
     end
 
+    new_value = BigDecimal(self, exception: false)&.round(currency.minor_units)
+    unless new_value.nil?
+      return Money.new(self, currency)
+    end
+
     Money::Parser::Fuzzy.parse(self, currency).tap do |money|
-      new_value = BigDecimal(self, exception: false)&.round(currency.minor_units)
       old_value = money.value
 
       if new_value != old_value
-        message = "`\"#{self}\".to_money` will soon behave like `Money.new(\"#{self}\")` and "
-        message +=
-          if new_value.nil?
-            "raise an ArgumentError exception. Use the browser's locale to parse money strings."
-          else
-            "return #{new_value} instead of #{old_value}."
-          end
+        message = "`\"#{self}\".to_money` will soon behave like `Money.new(\"#{self}\")` and " \
+          "raise an ArgumentError exception. Use the browser's locale to parse money strings."
+
         Money.deprecate(message)
       end
     end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -53,8 +53,9 @@ RSpec.describe String do
 
   it "#to_money to handle thousands delimiters" do
     configure(legacy_deprecations: true) do
-      expect(Money).to receive(:deprecate).exactly(4).times
-      expect("29.000".to_money("USD")).to eq(Money.new("29000", "USD"))
+      expect("29.000".to_money("USD")).to eq(Money.new("29.00", "USD"))
+
+      expect(Money).to receive(:deprecate).exactly(3).times
       expect("29.000,00".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29,000".to_money("USD")).to eq(Money.new("29000", "USD"))
       expect("29,000.00".to_money("USD")).to eq(Money.new("29000", "USD"))


### PR DESCRIPTION
# Why

Make `"1.123".to_money` behave consistently like `Money.new(1.123)` and have a value of `1.12`


# What

Remove deprecation warning for apps using `legacy_deprecation` option, and default to the correct behaviour

Note: This is a BREAKING CHANGE for apps using this option!