### PR TITLE
raise UnknownCurrency error when currency is invalid

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -52,16 +52,7 @@ class Money
       when 'xxx', 'XXX'
         Money::NULL_CURRENCY
       when String
-        begin
-          Currency.find!(currency)
-        rescue Money::Currency::UnknownCurrency => error
-          if Money.config.legacy_deprecations
-            Money.deprecate(error.message)
-            Money::NULL_CURRENCY
-          else
-            raise error
-          end
-        end
+        Currency.find!(currency)
       else
         raise ArgumentError, "could not parse as currency #{currency.inspect}"
       end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -89,11 +89,8 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_currency('usd')).to eq(Money::Currency.new('USD'))
     end
 
-    it 'returns the null currency when invalid iso is passed' do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).once
-        expect(subject.value_to_currency('invalid')).to eq(Money::NULL_CURRENCY)
-      end
+    it 'raises error when invalid iso is passed' do
+      expect { subject.value_to_currency('invalid') }.to raise_error(Money::Currency::UnknownCurrency)
     end
 
     it 'raises on invalid object' do


### PR DESCRIPTION
Issue: https://github.com/Shopify/shopify/issues/517112

# Why 

Support for invalid currency code has been deprecated and we want to remove support in V3. 

# What

Raise error when currency code is invalid when initializing a money object including reading from database. 