### PR TITLE
convert currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ Money::Currency.new("JPY").minor_units  # => 0
 Money::Currency.new("MGA").minor_units  # => 1
 ```
 
+### Convert Currency
+
+`Money.new(money * exchange_rate, "JPY")` will raise an exception. The valid alternatives are:
+
+```ruby
+Money.new(money.value * exchange_rate, "JPY")
+# Or
+money.convert_currency(exchange_rate, "JPY")
+```
+
 ## Money column
 
 Since money internally uses BigDecimal it's logical to use a `decimal` column

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -215,6 +215,10 @@ class Money
     [ReverseOperationProxy.new(other), self]
   end
 
+  def convert_currency(exchange_rate, new_currency)
+    Money.new(value * exchange_rate, new_currency)
+  end
+
   def to_money(new_currency = nil)
     if new_currency.nil?
       return self

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe "Money" do
     expect(Money.new(0, Money::NULL_CURRENCY)).to eq(Money.new(0))
   end
 
+  it "converts to a new currency" do
+    expect(Money.new(10, "USD").convert_currency(150, "JPY")).to eq(Money.new(1500, "JPY"))
+  end
+
   it "returns itself with to_money" do
     expect(money.to_money).to eq(money)
     expect(amount_money.to_money).to eq(amount_money)


### PR DESCRIPTION
# Why

`Money.new(money * exchange_rate, "JPY")` will raise an exception since `money * exchange_rate` returns a money object. A valid alternative is `Money.new(money.value * exchange_rate, "JPY")`

to avoid confusion, this PR provides a nice helper method that should be the prefered "explicit" way of doing currency conversions

# What

```ruby
money.convert_currency(exchange_rate, "JPY")
```