### PR TITLE
raise error when comparing or casting to a different currency

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -383,11 +383,7 @@ class Money
   def ensure_compatible_currency(other_currency, msg)
     return if currency.compatible?(other_currency)
 
-    if Money.config.legacy_deprecations
-      Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
-    else
-      raise Money::IncompatibleCurrencyError, msg
-    end
+    raise Money::IncompatibleCurrencyError, msg
   end
 
   def calculated_currency(other)


### PR DESCRIPTION
Issue: https://github.com/Shopify/shopify/issues/517120, https://github.com/Shopify/core-issues/issues/87436

# Why 

Removing support for
1. mathematical operation with different currencies
2. Casting the currency of an existing money object with currency to another currency

# What

Raise error if any of the above happens