### PR TITLE
arithmetic raises if unable to coerce to money

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -371,12 +371,7 @@ class Money
       yield(Money.new(other, currency))
 
     else
-      if Money.config.legacy_deprecations && other.respond_to?(:to_money)
-        Money.deprecate("#{other.inspect} is being implicitly coerced into a Money object. Call `to_money` on this object to transform it into a money explicitly. An TypeError will raise in the next major release")
-        yield(other.to_money(currency))
-      else
-        raise TypeError, "#{other.class.name} can't be coerced into Money"
-      end
+      raise TypeError, "#{other.class.name} can't be coerced into a Money object"
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -612,13 +612,13 @@ RSpec.describe "Money" do
             configure(legacy_deprecations: true) { test.run }
           end
 
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <=> coercible_object).to(eq(0)) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 >   coercible_object).to(eq(false)) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 >=  coercible_object).to(eq(true)) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <=  coercible_object).to(eq(true)) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <   coercible_object).to(eq(false)) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 +   coercible_object).to(eq(Money.new(20, 'CAD'))) }
-          it { expect(Money).to(receive(:deprecate).once); expect(cad_10 -   coercible_object).to(eq(Money.new(0, 'CAD'))) }
+          it { expect { cad_10 <=> coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 >   coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 >=  coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 <=  coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 <   coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 +   coercible_object }.to(raise_error(TypeError)) }
+          it { expect { cad_10 -   coercible_object }.to(raise_error(TypeError)) }
         end
       end
     end


### PR DESCRIPTION
# Why

Removing deprecations no longer needed for v3

# What

BREAKING CHANGE for people with the `legacy_deprecation` option enabled

We no longer try to coerce inside the gem by calling `to_money`. You need to do it on your own

```ruby
# before
your_own_object + Money.new(1)

# after
your_own_object.to_money + Money.new(1)
```