### PR TITLE
remove legacy_deprecation check for invalid strings

### DIFF
--- a/lib/money/parser/fuzzy.rb
+++ b/lib/money/parser/fuzzy.rb
@@ -92,8 +92,7 @@ class Money
         number = number.to_s.strip
 
         if number.empty?
-          if Money.config.legacy_deprecations && !strict
-            Money.deprecate("invalid money strings will raise in the next major release \"#{input}\"")
+          if !strict
             return '0'
           else
             raise MoneyFormatError, "invalid money string: #{input}"
@@ -120,9 +119,7 @@ class Money
           return amount.tr(ESCAPED_NON_COMMA_MARKS, '').sub(',', '.')
         end
 
-        if Money.config.legacy_deprecations && !strict
-          Money.deprecate("invalid money strings will raise in the next major release \"#{input}\"")
-        else
+        if strict
           raise MoneyFormatError, "invalid money string: #{input}"
         end
 

--- a/spec/parser/accounting_spec.rb
+++ b/spec/parser/accounting_spec.rb
@@ -20,10 +20,7 @@ RSpec.describe Money::Parser::Accounting do
     end
 
     it "parses an invalid string to $0" do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).once
-        expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
-      end
+      expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
     end
 
     it "parses a single digit integer string" do

--- a/spec/parser/fuzzy_spec.rb
+++ b/spec/parser/fuzzy_spec.rb
@@ -12,11 +12,8 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses an invalid string when not strict" do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).twice
-        expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
-        expect(@parser.parse("1..", 'USD')).to eq(Money.new(1, 'USD'))
-      end
+      expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
+      expect(@parser.parse("1..", 'USD')).to eq(Money.new(1, 'USD'))
     end
 
     it "parses raise with an invalid string and strict option" do
@@ -152,10 +149,7 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).once
-        expect(@parser.parse("1.1.11.111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
-      end
+      expect(@parser.parse("1.1.11.111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do
@@ -226,10 +220,7 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses amount with multiple inconsistent thousands delimiters" do
-      configure(legacy_deprecations: true) do
-        expect(Money).to receive(:deprecate).once
-        expect(@parser.parse("1,1,11,111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
-      end
+      expect(@parser.parse("1,1,11,111", 'USD')).to eq(Money.new(1_111_111, 'USD'))
     end
 
     it "parses raises with multiple inconsistent thousands delimiters and strict option" do


### PR DESCRIPTION
Issue: https://github.com/Shopify/shopify/issues/517173

# Why

Remove `legacy_deprecation` check when parsing invalid strings, but still maintaining support for non-strict behaviour.

# What

Technically no change in behaviour for non-strict string parsing, and just removing the `legacy_deprecation` check and emitting deprecation notice. 