### PR TITLE
Improve Fuzzy parsing with invalid strings

### DIFF
--- a/lib/money/parser/fuzzy.rb
+++ b/lib/money/parser/fuzzy.rb
@@ -74,7 +74,9 @@ class Money
       def parse(input, currency = nil, strict: false)
         currency = Money::Helpers.value_to_currency(currency)
         amount = extract_amount_from_string(input, currency, strict)
-        Money.new(amount, currency)
+        if amount
+          Money.new(amount, currency)
+        end
       end
 
       private
@@ -93,7 +95,7 @@ class Money
 
         if number.empty?
           if !strict
-            return '0'
+            return nil
           else
             raise MoneyFormatError, "invalid money string: #{input}"
           end

--- a/spec/parser/accounting_spec.rb
+++ b/spec/parser/accounting_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Money::Parser::Accounting do
       expect(@parser.parse("")).to eq(Money.new)
     end
 
-    it "parses an invalid string to $0" do
-      expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
+    it "parses an invalid string when not strict to nil" do
+      expect(@parser.parse("no money", 'USD')).to eq(nil)
     end
 
     it "parses a single digit integer string" do

--- a/spec/parser/fuzzy_spec.rb
+++ b/spec/parser/fuzzy_spec.rb
@@ -11,9 +11,15 @@ RSpec.describe Money::Parser::Fuzzy do
       expect(@parser.parse("")).to eq(Money.new(0, Money::NULL_CURRENCY))
     end
 
-    it "parses an invalid string when not strict" do
-      expect(@parser.parse("no money", 'USD')).to eq(Money.new(0, 'USD'))
+    it "parses an invalid string when not strict to nil" do
+      expect(@parser.parse("no money", 'USD')).to eq(nil)
+    end
+
+    it "parses a badly formatted numeric string when not strict to the closest approximation" do
       expect(@parser.parse("1..", 'USD')).to eq(Money.new(1, 'USD'))
+      expect(@parser.parse("1.000", 'USD')).to eq(Money.new(1, 'USD'))
+      expect(@parser.parse("1.1.1", 'USD')).to eq(Money.new(111, 'USD'))
+      expect(@parser.parse("1,1.11", 'USD')).to eq(Money.new(11.11, 'USD'))
     end
 
     it "parses raise with an invalid string and strict option" do


### PR DESCRIPTION
# Why

The fuzzy parsing tries to guess the amount from a string. We can get a little more strict about the guesses we're making

# What

- BREAKING CHANGE: In cases where it's not able to make a guess at all, we should return `nil` instead of `0`
