### PR TITLE
Support a "money string" format with `.to_money_string` and `Money.from_money_string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Money.new(50, "USD").clamp(1, 100) == Money.new(50, "USD")
 Money.from_subunits(500, "USD")  == Money.new(5, "USD")   # 5 USD
 Money.from_subunits(5, "JPY")    == Money.new(5, "JPY")   # 5 JPY
 Money.from_subunits(5000, "TND") == Money.new(5, "TND")   # 5 TND
+
+# String formatting
+m = Money.new(12.34, "CAD")
+m.to_s                                #=> "12.34"
+m.to_money_string                     #=> "CAD 12.34"
+Money.from_money_string("CAD 12.34")  #=> #<Money value:12.34 currency:CAD>
 ```
 
 ## Currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -74,6 +74,11 @@ class Money
       new(value, currency)
     end
 
+    def from_money_string(ms)
+      currency, value = ms.split(' ', 2)
+      new(value, currency)
+    end
+
     def rational(money1, money2)
       money1.send(:arithmetic, money2) do
         factor = money1.currency.subunit_to_unit * money2.currency.subunit_to_unit
@@ -258,6 +263,10 @@ class Money
   end
   alias_method :to_s, :to_fs
   alias_method :to_formatted_s, :to_fs
+
+  def to_money_string
+    "#{currency.to_s} #{to_s(:amount)}"
+  end
 
   def to_json(options = nil)
     if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe "Money" do
     expect{ Money.new(1, 'USD').to_money('CAD') }.to raise_error(Money::IncompatibleCurrencyError)
   end
 
+  it ".from_money_string" do
+    expect(Money.from_money_string("CAD 12.34")).to eq(Money.new(12.34, 'CAD'))
+  end
+
+  it "#to_money_string" do
+    expect(Money.new(12.34, 'CAD').to_money_string).to eq("CAD 12.34")
+  end
+
   it "defaults to 0 when constructed with no arguments" do
     expect(Money.new).to eq(Money.new(0))
   end


### PR DESCRIPTION
Looking for comments (and/or rude gestures) on adding a `money string` concept to promote simple/standard string representation of money with both amount and currency. 

Why? JSON and YAML (the currently supported formats) are great for some things, but for others (simple and efficient transport of money details) not so much.

I propose a string in the format of `<currency> <amount>` as the simplest most universal way to combine the two (with a space in-between) and have added 2 methods to do so along with entries to the readme for example usage.

Thoughts?