### PR TITLE
init configuration for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 100
+    registries: "*"


### PR DESCRIPTION
Our team got a notification that this wasn't configured and is required.

The dependencies are pretty minor in this case, but no harm in having this.