### PR TITLE
Introduce from_json as the inverse of to_json

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -280,6 +280,7 @@ class Money
       { value: to_s(:amount), currency: currency.to_s }
     end
   end
+  alias_method :to_h, :as_json
 
   def abs
     abs = value.abs

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'forwardable'
+require 'json'
 
 class Money
   include Comparable
@@ -72,6 +73,11 @@ class Money
 
       value = Helpers.value_to_decimal(subunits) / subunit_to_unit_value
       new(value, currency)
+    end
+
+    def from_json(string)
+      hash = JSON.parse(string, symbolize_names: true)
+      Money.new(hash.fetch(:value), hash.fetch(:currency))
     end
 
     def rational(money1, money2)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -80,6 +80,11 @@ class Money
       Money.new(hash.fetch(:value), hash.fetch(:currency))
     end
 
+    def from_hash(hash)
+      hash = hash.transform_keys(&:to_sym)
+      Money.new(hash.fetch(:value), hash.fetch(:currency))
+    end
+
     def rational(money1, money2)
       money1.send(:arithmetic, money2) do
         factor = money1.currency.subunit_to_unit * money2.currency.subunit_to_unit

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -388,6 +388,21 @@ RSpec.describe "Money" do
     expect(JSON.dump(Money.new(1.00, "CAD"))).to eq('{"value":"1.00","currency":"CAD"}')
   end
 
+  describe ".from_json" do
+    it "is the inverse operation of #to_json" do
+      one_cad = Money.new(1, "CAD")
+      expect(Money.from_json(one_cad.to_json)).to eq(one_cad)
+    end
+
+    it "creates Money object from JSON-encoded string" do
+      expect(Money.from_json('{ "value": 1.01, "currency": "CAD" }')).to eq(Money.new(1.01, "CAD"))
+    end
+
+    it "raises if JSON string is malformed" do
+      expect { Money.from_json('{ "val": 1.0 }') }.to raise_error(KeyError)
+    end
+  end
+
   it "supports absolute value" do
     expect(Money.new(-1.00).abs).to eq(Money.new(1.00))
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -388,6 +388,21 @@ RSpec.describe "Money" do
     expect(JSON.dump(Money.new(1.00, "CAD"))).to eq('{"value":"1.00","currency":"CAD"}')
   end
 
+  describe ".from_hash" do
+    it "is the inverse operation of #to_h" do
+      one_cad = Money.new(1, "CAD")
+      expect(Money.from_hash(one_cad.to_h)).to eq(one_cad)
+    end
+
+    it "creates Money object from hash with expected keys" do
+      expect(Money.from_hash({ value: 1.01, currency: "CAD" })).to eq(Money.new(1.01, "CAD"))
+    end
+
+    it "raises if Hash does not have the expected keys" do
+      expect { Money.from_hash({ "val": 1.0 }) }.to raise_error(KeyError)
+    end
+  end
+
   describe ".from_json" do
     it "is the inverse operation of #to_json" do
       one_cad = Money.new(1, "CAD")


### PR DESCRIPTION
The Money gem provides two JSON generating methods:
- `to_json` generates a JSON-encoded String representation of the Money object.
- `as_json` generates a JSON-encoded Hash representation of the Money object.

This PR introduces a class method that accepts any of these 2 JSON representations and generates a Money object from it.