### PR TITLE
default to the currency for thousand delimiter when unknown

### DIFF
--- a/lib/money/parser/fuzzy.rb
+++ b/lib/money/parser/fuzzy.rb
@@ -158,11 +158,6 @@ class Money
           return true
         end
 
-        # legacy support for 1.000 USD
-        if digits.last.size == 3 && digits.first.size <= 3 && currency.minor_units < 3
-          return false
-        end
-
         # The last mark matches the one used by the provided currency to delimiter decimals
         currency.decimal_mark == last_mark
       end

--- a/spec/parser/accounting_spec.rb
+++ b/spec/parser/accounting_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Money::Parser::Accounting do
 
     it "parses thousands amount" do
       Money.with_currency(Money::NULL_CURRENCY) do
-        expect(@parser.parse("1.000")).to eq(Money.new(1000.00))
+        expect(@parser.parse("1.000")).to eq(Money.new(1.00))
       end
     end
 

--- a/spec/parser/fuzzy_spec.rb
+++ b/spec/parser/fuzzy_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Money::Parser::Fuzzy do
     end
 
     it "parses no currency amount" do
-      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1000, Money::NULL_CURRENCY))
+      expect(@parser.parse("1.000", Money::NULL_CURRENCY)).to eq(Money.new(1, Money::NULL_CURRENCY))
     end
 
     it "parses amount with more than 3 decimals correctly" do
@@ -246,7 +246,7 @@ RSpec.describe Money::Parser::Fuzzy do
   describe "no decimal currency" do
     it "parses thousands correctly" do
       expect(@parser.parse("1,111", "JPY")).to eq(Money.new(1_111, 'JPY'))
-      expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1_111, 'JPY'))
+      expect(@parser.parse("1.111", "JPY")).to eq(Money.new(1, 'JPY'))
       expect(@parser.parse("1 111", "JPY")).to eq(Money.new(1_111, 'JPY'))
       expect(@parser.parse("1111,111", "JPY")).to eq(Money.new(1_111_111, 'JPY'))
     end
@@ -261,7 +261,7 @@ RSpec.describe Money::Parser::Fuzzy do
   describe "two decimal currency" do
     it "parses thousands correctly" do
       expect(@parser.parse("1,111", "USD")).to eq(Money.new(1_111, 'USD'))
-      expect(@parser.parse("1.111", "USD")).to eq(Money.new(1_111, 'USD'))
+      expect(@parser.parse("1.111", "USD")).to eq(Money.new(1.11, 'USD'))
       expect(@parser.parse("1 111", "USD")).to eq(Money.new(1_111, 'USD'))
       expect(@parser.parse("1111,111", "USD")).to eq(Money.new(1_111_111, 'USD'))
     end


### PR DESCRIPTION
# Why

The fuzzy parsing tries to guess the amount from a string. We can get a little more strict about the guesses we're making

# What

When we're not able to guess if the delimiter is for thousands or decimals, defer to the currency decimal delimiter
