### PR TITLE
Do not `delete` from frozen `options` passed to `as_json`

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -260,7 +260,7 @@ class Money
   alias_method :to_formatted_s, :to_fs
 
   def to_json(options = nil)
-    if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format
+    if (options.is_a?(Hash) && options[:legacy_format]) || Money.config.legacy_json_format
       to_s
     else
       as_json(options).to_json
@@ -268,7 +268,7 @@ class Money
   end
 
   def as_json(options = nil)
-    if (options.is_a?(Hash) && options.delete(:legacy_format)) || Money.config.legacy_json_format
+    if (options.is_a?(Hash) && options[:legacy_format]) || Money.config.legacy_json_format
       to_s
     else
       { value: to_s(:amount), currency: currency.to_s }


### PR DESCRIPTION
Next version of Rails will freeze `options` passed to `as_json` which means `.delete` will raise an error. https://github.com/rails/rails/pull/52826

In our case it should be safe to just check for `legacy_format` key value and keep it since it shouldn't impact serialization. 


### Alternative

As an alternative we could `dup` options ourselves but this will harm performance so I prefer to avoid it unless we are aware of a specific issue with keeping unnecessary keys in the `options`

