### PR TITLE
Limit caller stack size in deprecation event

### DIFF
--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -31,7 +31,7 @@ Money.class_eval do
     end
   else
     def self.caller_stack
-      caller_locations.reject do |location|
+      caller_locations(2, DEPRECATION_STACKTRACE_LENGTH * 2).reject do |location|
         location.path.include?('gems/shopify-money')
       end
     end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4518e818-4a65-4ded-898f-213c941be6cf)

There are reports that `caller_locations` calls from the money gem are noticeable on allocations profiles which potentially impacts performance (leads to an increased number of garbage collection cycles)

This is due to `caller_locations` eagerly getting full stack which is rarely needed. The common practice is either limit the number of entries by passing `start, length` as arguments but in this case since we need to filter some entries we'll use `Thread.each_caller_location` which iterates over stack entries one by one until we build a list of `5` (feel free to suggest different size) locations.

`Thread.each_caller_location` is available from Ruby 3.2 but the gem still supports `3.0` thus the `Thread.respond_to?(:each_caller_location)` branch. The branch can be cleaned up once the gem drops support for Ruby 3.1


### Simplified benchmark
it's not very representative since real production stack traces will differ 

```ruby
require "benchmark/ips"

def partial_stack
  stack = []
  Thread.each_caller_location do |location|
    stack << location unless location.path.include?('gems/shopify-money')
    break if stack.length == 5
  end
  stack
end

def caller_locations_full
  caller_locations.reject do |location|
    location.to_s.include?('gems/shopify-money')
  end
end

def deep(count, &block)
  if count == 0
    yield
  else
    deep(count - 1, &block)
  end
end

deep(50) do
  Benchmark.ips do |x|
    x.report("partial_stack") do
      partial_stack
    end

    x.report("caller_locations_full") do
      caller_locations_full
    end

    x.compare!
  end
end
```

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Warming up --------------------------------------
       partial_stack    48.080k i/100ms
caller_locations_full
                         2.264k i/100ms
Calculating -------------------------------------
       partial_stack    478.039k (± 2.7%) i/s    (2.09 μs/i) -      2.404M in   5.032862s
caller_locations_full
                         22.278k (± 3.4%) i/s   (44.89 μs/i) -    113.200k in   5.087842s

Comparison:
       partial_stack:   478039.2 i/s
caller_locations_full:    22278.0 i/s - 21.46x  slower
```