### PR TITLE
Handle when ActiveJob::Serializers is not defined in older versions of Rails

### DIFF
--- a/lib/money/railtie.rb
+++ b/lib/money/railtie.rb
@@ -4,8 +4,10 @@ class Money
   class Railtie < Rails::Railtie
     initializer "shopify-money.setup_active_job_serializer" do
       ActiveSupport.on_load(:active_job) do
-        require_relative "rails/job_argument_serializer"
-        ActiveJob::Serializers.add_serializers(::Money::Rails::JobArgumentSerializer)
+        if defined?(ActiveJob::Serializers)
+          require_relative "rails/job_argument_serializer"
+          ActiveJob::Serializers.add_serializers(::Money::Rails::JobArgumentSerializer)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/money/issues/263