### PR TITLE
Return up to the first 2 currencies before continuing in Allocator

### DIFF
--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -139,8 +139,9 @@ class Money
 
     def extract_currency(money_array)
       currencies = money_array.lazy.select do |money|
-        money.is_a?(Money)
-      end.reject(&:no_currency?).map(&:currency).to_a.uniq
+        money.is_a?(Money) && !money.no_currency?
+      end.map(&:currency).uniq.first(2)
+
       if currencies.size > 1
         raise ArgumentError,
           "operation not permitted for Money objects with different currencies #{currencies.join(", ")}"

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1075,7 +1075,7 @@ RSpec.describe "Money" do
     it "only sends a callstack of events outside of the money gem" do
       expect_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(
         -> (message) { message == "[Shopify/Money] message\n" },
-        -> (callstack) { !callstack.first.to_s.include?('gems/money') && callstack.size > 0 }
+        -> (callstack) { !callstack.empty? && !callstack.first.to_s.include?('gems/money') }
       )
       Money.deprecate('message')
     end


### PR DESCRIPTION
If we have more than one currency, we will throw an error, so once we have 2, we can stop processing more.

Also changes `callstack.size > 0` to `!callstack.empty?` in a test.