### PR TITLE
Add USDC stablecoin to `currency_non_iso.yml`

### DIFF
--- a/config/currency_non_iso.yml
+++ b/config/currency_non_iso.yml
@@ -102,7 +102,7 @@ usdc:
   disambiguate_symbol: USDC
   alternate_symbols: []
   subunit: Cent
-  subunit_to_unit: 1000000,
+  subunit_to_unit: 100,
   symbol_first: false
   html_entity: "$"
   decimal_mark: "."


### PR DESCRIPTION
### What is being done?
We (Post purchase order management) recently encountered the following exception: https://github.com/Shopify/shopify/issues/557605 TL;DR - We've imported a balance transaction into Shopify Payments from Stripe that has a currency of USDC. It seems when we call the Shopify money gem it throws `[Shopify/Money] Invalid iso4217 currency 'USDC' `. 

### Why is it being done?
We need to add this currency to support surfacing USDC transactions in Shopify properly. Also there is a initiative in the future for Shopify Payments to support USDC stablecoin. 