### PR TITLE
trim whitespace on `value_to_currency` when string

### DIFF
--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -50,7 +50,7 @@ class Money
         Money::NULL_CURRENCY
       when String
         begin
-          Currency.find!(currency)
+          Currency.find!(currency.strip)
         rescue Money::Currency::UnknownCurrency => error
           if Money.config.legacy_deprecations
             Money.deprecate(error.message)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe Money::Helpers do
       expect(subject.value_to_currency('usd')).to eq(Money::Currency.new('USD'))
     end
 
+    it 'trims whitespace' do
+      expect(subject.value_to_currency(' usd ')).to eq(Money::Currency.new('USD'))
+    end
+
     it 'returns the null currency when invalid iso is passed' do
       configure(legacy_deprecations: true) do
         expect(Money).to receive(:deprecate).once


### PR DESCRIPTION
Encountered an issue with whitespace in the `value_to_currency` method [here](https://app.bugsnag.com/shopify/shopify-production/timeline?filters[error]=66d98907c3d03a3f32627752&filters[event.since]=30d)

Ideally we shouldn't have leading or trailing whitespace for currencies passed in, but this is a simple bit of string preprocessing that might help alleviate some unintended errors.