### PR TITLE
scope down unsafe currency usage

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
-    configure(legacy_deprecations: true) do
+    Money.unsafe do
       expect(Money).to receive(:deprecate).with(match(/to_money is attempting to change currency of an existing money object/)).once
       expect(Money.new(1, 'USD').to_money('CAD')).to eq(Money.new(1, 'USD'))
     end
@@ -102,7 +102,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations constructor with money used the constructor currency" do
-    configure(legacy_deprecations: true) do
+    Money.unsafe do
      expect(Money).to receive(:deprecate).with(match(/Money.new\(Money.new\(amount, USD\), CAD\) is changing the currency of an existing money object/)).once
       expect(Money.new(Money.new(1, 'USD'), 'CAD')).to eq(Money.new(1, 'CAD'))
     end
@@ -214,7 +214,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations adds inconsistent currencies" do
-    configure(legacy_deprecations: true) do
+    Money.unsafe do
       expect(Money).to receive(:deprecate).once
       expect(Money.new(5, 'USD') + Money.new(1, 'CAD')).to eq(Money.new(6, 'USD'))
     end
@@ -237,7 +237,7 @@ RSpec.describe "Money" do
   end
 
   it "logs a deprecation warning when adding across currencies" do
-    configure(legacy_deprecations: true) do
+    Money.unsafe do
       expect(Money).to receive(:deprecate).with(match(/mathematical operation not permitted for Money objects with different currencies/))
       expect(Money.new(10, 'USD') - Money.new(1, 'JPY')).to eq(Money.new(9, 'USD'))
     end
@@ -476,7 +476,7 @@ RSpec.describe "Money" do
   it "generates a true rational" do
     expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'USD'))).to eq(Rational(2,3))
 
-    configure(legacy_deprecations: true) do
+    Money.unsafe do
       expect(Money).to receive(:deprecate).once
       expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'JPY'))).to eq(Rational(2,3))
     end
@@ -562,7 +562,7 @@ RSpec.describe "Money" do
     end
 
     it "<=> issues deprecation warning when comparing incompatible currency" do
-      configure(legacy_deprecations: true) do
+      Money.unsafe do
         expect(Money).to receive(:deprecate).twice
         expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(-1)
         expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(1)
@@ -590,7 +590,7 @@ RSpec.describe "Money" do
 
       describe('legacy different currencies') do
         around(:each) do |test|
-          configure(legacy_deprecations: true) { test.run }
+          Money.unsafe { test.run }
         end
 
         it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <=> usd_10).to(eq(0)) }


### PR DESCRIPTION
# Why

rather than a config that applies to the whole repo, this will allow us to go case by case and remove the outstanding legacy behaviour

# What

In both cases a deprecation warning will be generated

```ruby
# before

Money.config.legacy_deprecations! # can still be used for other deprecations than cross-currency

# after

Money.unsafe { money1 + money2 }
```