### PR TITLE
scope down unsafe currency usage

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -107,12 +107,24 @@ class Money
     # the previous value when done to prevent leaking state. Similar to
     # I18n.with_locale and ActiveSupport's Time.use_zone. This won't affect
     # instances being created with explicitly set currency.
-    def with_currency(new_currency)
+    def with_currency(new_currency, &block)
       old_currency = Money.current_currency
       Money.current_currency = new_currency
       yield
     ensure
       Money.current_currency = old_currency
+    end
+
+    def current_cross_currency_deprecation
+      Thread.current[:money_gem_cross_currency_deprecation]
+    end
+
+    def cross_currency_deprecation(&block)
+      # Get cross-currency deprecation instead of exception
+      Thread.current[:money_gem_cross_currency_deprecation] = true
+      yield
+    ensure
+      Thread.current[:money_gem_cross_currency_deprecation] = false
     end
 
     private
@@ -131,7 +143,7 @@ class Money
       msg = "Money.new(Money.new(amount, #{amount.currency}), #{currency}) " \
         "is changing the currency of an existing money object"
 
-      if Money.config.legacy_deprecations
+      if Money.current_cross_currency_deprecation
         Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
         Money.new(amount.value, currency)
       else
@@ -401,7 +413,7 @@ class Money
   def ensure_compatible_currency(other_currency, msg)
     return if currency.compatible?(other_currency)
 
-    if Money.config.legacy_deprecations
+    if Money.current_cross_currency_deprecation
       Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
     else
       raise Money::IncompatibleCurrencyError, msg

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -56,9 +56,15 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
-    Money.cross_currency_deprecation do
+    Money.with_legacy_deprecations do
       expect(Money).to receive(:deprecate).with(match(/to_money is attempting to change currency of an existing money object/)).once
       expect(Money.new(1, 'USD').to_money('CAD')).to eq(Money.new(1, 'USD'))
+    end
+  end
+
+  it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
+    Money.without_legacy_deprecations do
+      expect{ Money.new(1, 'USD').to_money('CAD') }.to raise_error(Money::IncompatibleCurrencyError)
     end
   end
 
@@ -102,7 +108,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations constructor with money used the constructor currency" do
-    Money.cross_currency_deprecation do
+    Money.with_legacy_deprecations do
      expect(Money).to receive(:deprecate).with(match(/Money.new\(Money.new\(amount, USD\), CAD\) is changing the currency of an existing money object/)).once
       expect(Money.new(Money.new(1, 'USD'), 'CAD')).to eq(Money.new(1, 'CAD'))
     end
@@ -214,7 +220,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations adds inconsistent currencies" do
-    Money.cross_currency_deprecation do
+    Money.with_legacy_deprecations do
       expect(Money).to receive(:deprecate).once
       expect(Money.new(5, 'USD') + Money.new(1, 'CAD')).to eq(Money.new(6, 'USD'))
     end
@@ -237,7 +243,7 @@ RSpec.describe "Money" do
   end
 
   it "logs a deprecation warning when adding across currencies" do
-    Money.cross_currency_deprecation do
+    Money.with_legacy_deprecations do
       expect(Money).to receive(:deprecate).with(match(/mathematical operation not permitted for Money objects with different currencies/))
       expect(Money.new(10, 'USD') - Money.new(1, 'JPY')).to eq(Money.new(9, 'USD'))
     end
@@ -476,7 +482,7 @@ RSpec.describe "Money" do
   it "generates a true rational" do
     expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'USD'))).to eq(Rational(2,3))
 
-    Money.cross_currency_deprecation do
+    Money.with_legacy_deprecations do
       expect(Money).to receive(:deprecate).once
       expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'JPY'))).to eq(Rational(2,3))
     end
@@ -562,7 +568,7 @@ RSpec.describe "Money" do
     end
 
     it "<=> issues deprecation warning when comparing incompatible currency" do
-      Money.cross_currency_deprecation do
+      Money.with_legacy_deprecations do
         expect(Money).to receive(:deprecate).twice
         expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(-1)
         expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(1)
@@ -590,7 +596,7 @@ RSpec.describe "Money" do
 
       describe('legacy different currencies') do
         around(:each) do |test|
-          Money.cross_currency_deprecation { test.run }
+          Money.with_legacy_deprecations { test.run }
         end
 
         it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <=> usd_10).to(eq(0)) }

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations #to_money doesn't overwrite the money object's currency" do
-    configure(legacy_deprecations: true) do
+    Money.cross_currency_deprecation do
       expect(Money).to receive(:deprecate).with(match(/to_money is attempting to change currency of an existing money object/)).once
       expect(Money.new(1, 'USD').to_money('CAD')).to eq(Money.new(1, 'USD'))
     end
@@ -102,7 +102,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations constructor with money used the constructor currency" do
-    configure(legacy_deprecations: true) do
+    Money.cross_currency_deprecation do
      expect(Money).to receive(:deprecate).with(match(/Money.new\(Money.new\(amount, USD\), CAD\) is changing the currency of an existing money object/)).once
       expect(Money.new(Money.new(1, 'USD'), 'CAD')).to eq(Money.new(1, 'CAD'))
     end
@@ -214,7 +214,7 @@ RSpec.describe "Money" do
   end
 
   it "legacy_deprecations adds inconsistent currencies" do
-    configure(legacy_deprecations: true) do
+    Money.cross_currency_deprecation do
       expect(Money).to receive(:deprecate).once
       expect(Money.new(5, 'USD') + Money.new(1, 'CAD')).to eq(Money.new(6, 'USD'))
     end
@@ -237,7 +237,7 @@ RSpec.describe "Money" do
   end
 
   it "logs a deprecation warning when adding across currencies" do
-    configure(legacy_deprecations: true) do
+    Money.cross_currency_deprecation do
       expect(Money).to receive(:deprecate).with(match(/mathematical operation not permitted for Money objects with different currencies/))
       expect(Money.new(10, 'USD') - Money.new(1, 'JPY')).to eq(Money.new(9, 'USD'))
     end
@@ -476,7 +476,7 @@ RSpec.describe "Money" do
   it "generates a true rational" do
     expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'USD'))).to eq(Rational(2,3))
 
-    configure(legacy_deprecations: true) do
+    Money.cross_currency_deprecation do
       expect(Money).to receive(:deprecate).once
       expect(Money.rational(Money.new(10.0, 'USD'), Money.new(15.0, 'JPY'))).to eq(Rational(2,3))
     end
@@ -562,7 +562,7 @@ RSpec.describe "Money" do
     end
 
     it "<=> issues deprecation warning when comparing incompatible currency" do
-      configure(legacy_deprecations: true) do
+      Money.cross_currency_deprecation do
         expect(Money).to receive(:deprecate).twice
         expect(Money.new(1000, 'USD') <=> Money.new(2000, 'JPY')).to eq(-1)
         expect(Money.new(2000, 'JPY') <=> Money.new(1000, 'USD')).to eq(1)
@@ -590,7 +590,7 @@ RSpec.describe "Money" do
 
       describe('legacy different currencies') do
         around(:each) do |test|
-          configure(legacy_deprecations: true) { test.run }
+          Money.cross_currency_deprecation { test.run }
         end
 
         it { expect(Money).to(receive(:deprecate).once); expect(cad_10 <=> usd_10).to(eq(0)) }


### PR DESCRIPTION
# Why

rather than a config that applies to the whole repo, this will allow us to go case by case and remove the outstanding legacy behaviour. This will also unblock opt-in to get exceptions for those wanting to rescue `Money::IncompatibleCurrencyError` directly

# What

```ruby
# before

Money.config.legacy_deprecations!
moneyUSD + moneyCAD #=> deprecation warning

# after

Money.config.legacy_deprecations!
moneyUSD + moneyCAD #=> deprecation warning
Money.without_legacy_deprecations { moneyUSD + moneyCAD } #=> raise Money::IncompatibleCurrencyError

# once Money.config.legacy_deprecations! is removed
Money.with_legacy_deprecations { moneyUSD + moneyCAD } #=> deprecation warning
moneyUSD + moneyCAD #=> raise Money::IncompatibleCurrencyError
```