### PR TITLE
Remove subunit symbols

### DIFF
--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -420,7 +420,6 @@ cad:
   alternate_symbols:
   - C$
   - CAD$
-  subunit_symbol: "¢"
   subunit: Cent
   subunit_to_unit: 100
   symbol_first: true
@@ -758,7 +757,6 @@ gbp:
   name: British Pound
   symbol: "£"
   alternate_symbols: []
-  subunit_symbol: p
   subunit: Penny
   subunit_to_unit: 100
   symbol_first: true
@@ -2262,7 +2260,6 @@ usd:
   alternate_symbols:
   - US$
   subunit: Cent
-  subunit_symbol: "¢"
   subunit_to_unit: 100
   symbol_first: true
   html_entity: "$"

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -47,7 +47,6 @@ class Money
     def initialize
       @symbol                = '$'
       @disambiguate_symbol   = nil
-      @subunit_symbol        = nil
       @iso_code              = 'XXX'
       @iso_numeric           = '999'
       @name                  = 'No Currency'

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Currency" do
     "minor_units": 2,
     "symbol": '$',
     "disambiguate_symbol": "US$",
-    "subunit_symbol": "¢",
     "decimal_mark": ".",
   }
 


### PR DESCRIPTION
subunit symbols are not maintained consistently, better to remove them all together and set the correct expectation