### PR TITLE
no subunits for HUF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ doc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored
@@ -48,3 +48,4 @@ pkg
 #*.rbc
 
 .rspec_status
+.DS_Store

--- a/config/currency_iso.yml
+++ b/config/currency_iso.yml
@@ -940,7 +940,7 @@ huf:
   symbol: Ft
   alternate_symbols: []
   subunit: ''
-  subunit_to_unit: 100
+  subunit_to_unit: 1
   symbol_first: false
   html_entity: ''
   decimal_mark: ","


### PR DESCRIPTION
https://github.com/RubyMoney/money/issues/677#issue-202864984

PayPal agrees with this and does not support decimals (will return an error if provided) https://developer.paypal.com/reference/currency-codes/

[Stripe](https://docs.stripe.com/currencies) also says the same
<img width="924" alt="Screenshot 2025-02-25 at 2 57 20 PM" src="https://github.com/user-attachments/assets/002efc06-20ed-45d5-8a24-56b928b2879b" />

