### PR TITLE
new without_legacy_deprecations method

### DIFF
--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -21,5 +21,13 @@ class Money
       @legacy_json_format = false
       @legacy_deprecations = false
     end
+
+    def without_legacy_deprecations(&block)
+      old_legacy_deprecations = @legacy_deprecations
+      @legacy_deprecations = false
+      yield
+    ensure
+      @legacy_deprecations = old_legacy_deprecations
+    end
   end
 end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -39,7 +39,7 @@ class Money
 
   class << self
     extend Forwardable
-    def_delegators :config, :default_currency, :default_currency=
+    def_delegators :config, :default_currency, :default_currency=, :without_legacy_deprecations
 
     def config
       Thread.current[:shopify_money__config] ||= Config.new

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,6 +2,20 @@
 require 'spec_helper'
 
 RSpec.describe "Money::Config" do
+  describe 'thread safety' do
+    it 'does not share the same config across threads' do
+      configure(legacy_deprecations: true, default_currency: 'USD') do
+        expect(Money.config.legacy_deprecations).to eq(true)
+        expect(Money.default_currency).to eq('USD')
+        thread = Thread.new do
+          expect(Money.config.legacy_deprecations).to eq(false)
+          expect(Money.default_currency).to eq(nil)
+        end
+        thread.join
+      end
+    end
+  end
+
   describe 'legacy_deprecations' do
     it "respects the default currency" do
       configure(default_currency: 'USD', legacy_deprecations: true) do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe "Money" do
     end
   end
 
+  it "#without_legacy_deprecations bypasses the legacy deprecations and gives the real behavior" do
+    configure(legacy_deprecations: true) do
+      Money.without_legacy_deprecations do
+        expect{ Money.new(1, 'USD').to_money('CAD') }.to raise_error(Money::IncompatibleCurrencyError)
+      end
+    end
+  end
+
   it "#to_money raises when changing currency" do
     expect{ Money.new(1, 'USD').to_money('CAD') }.to raise_error(Money::IncompatibleCurrencyError)
   end


### PR DESCRIPTION
## Why

apps using the `config.legacy_deprecations!` configuration need a way to trigger new behaviour to rescue exceptions before completely removing this configuration


## What

add a `without_legacy_deprecations` method

```ruby
    Money.without_legacy_deprecations do
        Money.new(1, 'USD') + Money.new(1, 'CAD') #=> raise Money::IncompatibleCurrencyError
    end
```