### PR TITLE
Bump to v3.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (3.0.0)
+    shopify-money (3.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
## What's Changed
* Introduce from_json as the inverse of to_json by @pedropb in https://github.com/Shopify/money/pull/326
* Bump rexml from 3.2.8 to 3.3.2 in the bundler group by @dependabot in https://github.com/Shopify/money/pull/324
* Bump rexml from 3.3.2 to 3.3.6 in the bundler group by @dependabot in https://github.com/Shopify/money/pull/333
* Rails 7.2 would allow up to update sqlite3 adaptor as well to keep up to date by @bslobodin in https://github.com/Shopify/money/pull/334
* `bundle update rubocop` by @bslobodin in https://github.com/Shopify/money/pull/335
* Do not `delete` from frozen `options` passed to `as_json` by @nvasilevski in https://github.com/Shopify/money/pull/337
* Add Rubocop by @elfassy in https://github.com/Shopify/money/pull/339
* Limit caller stack size in deprecation event by @nvasilevski in https://github.com/Shopify/money/pull/342
* Update .ruby-version to 3.3.5 by @ryanseys in https://github.com/Shopify/money/pull/344
* Handle when ActiveJob::Serializers is not defined in older versions of Rails by @ryanseys in https://github.com/Shopify/money/pull/345
* Bump dependencies by @ryanseys in https://github.com/Shopify/money/pull/348
* Use RuboCop::Cop::Base by @etiennebarrie in https://github.com/Shopify/money/pull/349
* Update currencies by @elfassy in https://github.com/Shopify/money/pull/358
* new without_legacy_deprecations method by @elfassy in https://github.com/Shopify/money/pull/362

## New Contributors
* @pedropb made their first contribution in https://github.com/Shopify/money/pull/326
* @nvasilevski made their first contribution in https://github.com/Shopify/money/pull/337
* @ryanseys made their first contribution in https://github.com/Shopify/money/pull/344
* @etiennebarrie made their first contribution in https://github.com/Shopify/money/pull/349

**Full Changelog**: https://github.com/Shopify/money/compare/v3.0.0...main