### PR TITLE
required ruby version is 3.1

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("simplecov", ">= 0")
   s.add_development_dependency("sqlite3")
 
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.files = %x(git ls-files).split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
# Why

<img width="908" alt="Screenshot 2025-02-19 at 10 21 38 AM" src="https://github.com/user-attachments/assets/3af62651-011a-4c0b-8ac1-e0eec3648207" />

required since https://github.com/Shopify/money/pull/334/commits/4f9bedb5de4458c1dd82d3c21b8c6acf1f9f61d9

# What

updated the gemspec