### PR TITLE
revert to defining the config as a class variable

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -42,7 +42,7 @@ class Money
     def_delegators :config, :default_currency, :default_currency=, :without_legacy_deprecations
 
     def config
-      Thread.current[:shopify_money__config] ||= Config.new
+      Thread.current[:shopify_money__config] ||= @config.dup
     end
 
     def config=(config)
@@ -50,7 +50,8 @@ class Money
     end
 
     def configure
-      yield(config) if block_given?
+      @config ||= Config.new
+      yield(@config) if block_given?
     end
 
     def new(value = 0, currency = nil)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -4,14 +4,18 @@ require 'spec_helper'
 RSpec.describe "Money::Config" do
   describe 'thread safety' do
     it 'does not share the same config across threads' do
-      configure(legacy_deprecations: true, default_currency: 'USD') do
-        expect(Money.config.legacy_deprecations).to eq(true)
-        expect(Money.default_currency).to eq('USD')
+      configure(legacy_deprecations: false, default_currency: 'USD') do
+        expect(Money.config.legacy_deprecations).to eq(false)
+        expect(Money.config.default_currency).to eq('USD')
         thread = Thread.new do
-          expect(Money.config.legacy_deprecations).to eq(false)
-          expect(Money.default_currency).to eq(nil)
+          Money.config.legacy_deprecations!
+          Money.default_currency = "EUR"
+          expect(Money.config.legacy_deprecations).to eq(true)
+          expect(Money.config.default_currency).to eq("EUR")
         end
         thread.join
+        expect(Money.config.legacy_deprecations).to eq(false)
+        expect(Money.config.default_currency).to eq('USD')
       end
     end
   end


### PR DESCRIPTION
# Why

When `Money.configure` is used in an initializer, it doesn't share the same thread as the execution of the code. This meant that the config was always reset to it's default values and would not use the app's customizations

# What

revert to using a class variable for the default configuration, from which the current thread configs are based on