### PR TITLE
Increase deprecation stack trace size

### DIFF
--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -2,7 +2,7 @@
 
 Money.class_eval do
   ACTIVE_SUPPORT_DEFINED = defined?(ActiveSupport)
-  DEPRECATION_STACKTRACE_LENGTH = 5
+  DEPRECATION_STACKTRACE_LENGTH = 20
 
   def self.active_support_deprecator
     @active_support_deprecator ||= begin


### PR DESCRIPTION
5 stack trace lines is too few, especially when money is wrapped by other classes in an app - you end up with at most 1 line of relevant execution context.