### PR TITLE
move thread config to `Money::Config.current`

### DIFF
--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -2,7 +2,19 @@
 
 class Money
   class Config
+    class << self
+      def current
+        Thread.current[:shopify_money__config] ||= Money.config.dup
+      end
+
+      def current=(config)
+        Thread.current[:shopify_money__config] = config
+      end
+    end
+
     attr_accessor :default_currency, :legacy_json_format, :legacy_deprecations
+    alias_method :current_currency, :default_currency
+    alias_method :current_currency=, :default_currency=
 
     def legacy_default_currency!
       @default_currency ||= Money::NULL_CURRENCY
@@ -28,6 +40,14 @@ class Money
       yield
     ensure
       @legacy_deprecations = old_legacy_deprecations
+    end
+
+    def with_currency(new_currency)
+      old_currency = current_currency
+      self.current_currency = new_currency
+      yield
+    ensure
+      self.current_currency = old_currency
     end
   end
 end

--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -17,7 +17,7 @@ class String
   def to_money(currency = nil)
     currency = Money::Helpers.value_to_currency(currency)
 
-    unless Money.config.legacy_deprecations
+    unless Money::Config.current.legacy_deprecations
       return Money.new(self, currency)
     end
 

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -43,7 +43,7 @@ class Money
       when Money::Currency, Money::NullCurrency
         currency
       when nil, ''
-        default = Money.current_currency || Money.default_currency
+        default = Money::Config.current.default_currency
         raise(Money::Currency::UnknownCurrency, 'missing currency') if default.nil? || default == ''
         value_to_currency(default)
       when 'xxx', 'XXX'
@@ -52,7 +52,7 @@ class Money
         begin
           Currency.find!(currency)
         rescue Money::Currency::UnknownCurrency => error
-          if Money.config.legacy_deprecations
+          if Money::Config.current.legacy_deprecations
             Money.deprecate(error.message)
             Money::NULL_CURRENCY
           else

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -39,19 +39,21 @@ class Money
 
   class << self
     extend Forwardable
-    def_delegators :config, :default_currency, :default_currency=, :without_legacy_deprecations
-
-    def config
-      Thread.current[:shopify_money__config] ||= @config.dup
-    end
-
-    def config=(config)
-      Thread.current[:shopify_money__config] = config
-    end
+    def_delegators(:config, :default_currency, :default_currency=)
+    def_delegators(
+      :'Money::Config.current',
+      :without_legacy_deprecations,
+      :current_currency,
+      :current_currency=,
+      :with_currency,
+    )
 
     def configure
+      yield(config) if block_given?
+    end
+
+    def config
       @config ||= Config.new
-      yield(@config) if block_given?
     end
 
     def new(value = 0, currency = nil)
@@ -101,26 +103,6 @@ class Money
       end
     end
 
-    def current_currency
-      Thread.current[:money_currency]
-    end
-
-    def current_currency=(currency)
-      Thread.current[:money_currency] = currency
-    end
-
-    # Set Money.default_currency inside the supplied block, resets it to
-    # the previous value when done to prevent leaking state. Similar to
-    # I18n.with_locale and ActiveSupport's Time.use_zone. This won't affect
-    # instances being created with explicitly set currency.
-    def with_currency(new_currency)
-      old_currency = Money.current_currency
-      Money.current_currency = new_currency
-      yield
-    ensure
-      Money.current_currency = old_currency
-    end
-
     private
 
     def new_from_money(amount, currency)
@@ -137,7 +119,7 @@ class Money
       msg = "Money.new(Money.new(amount, #{amount.currency}), #{currency}) " \
         "is changing the currency of an existing money object"
 
-      if Money.config.legacy_deprecations
+      if Money::Config.current.legacy_deprecations
         Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
         Money.new(amount.value, currency)
       else
@@ -145,7 +127,6 @@ class Money
       end
     end
   end
-  configure
 
   def initialize(value, currency)
     raise ArgumentError if value.nan?
@@ -286,7 +267,7 @@ class Money
   alias_method :to_formatted_s, :to_fs
 
   def to_json(options = nil)
-    if (options.is_a?(Hash) && options[:legacy_format]) || Money.config.legacy_json_format
+    if (options.is_a?(Hash) && options[:legacy_format]) || Money::Config.current.legacy_json_format
       to_s
     else
       as_json(options).to_json
@@ -294,7 +275,7 @@ class Money
   end
 
   def as_json(options = nil)
-    if (options.is_a?(Hash) && options[:legacy_format]) || Money.config.legacy_json_format
+    if (options.is_a?(Hash) && options[:legacy_format]) || Money::Config.current.legacy_json_format
       to_s
     else
       { value: to_s(:amount), currency: currency.to_s }
@@ -407,7 +388,7 @@ class Money
   def ensure_compatible_currency(other_currency, msg)
     return if currency.compatible?(other_currency)
 
-    if Money.config.legacy_deprecations
+    if Money::Config.current.legacy_deprecations
       Money.deprecate("#{msg}. A Money::IncompatibleCurrencyError will raise in the next major release")
     else
       raise Money::IncompatibleCurrencyError, msg

--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -60,7 +60,7 @@ module MoneyColumn
         currency = options[:currency] || try(options[:currency_column])
         if currency && !money.currency.compatible?(Money::Helpers.value_to_currency(currency))
           msg = "[money_column] currency mismatch between #{currency} and #{money.currency} in column #{column}."
-          if Money.config.legacy_deprecations
+          if Money::Config.current.legacy_deprecations
             Money.deprecate(msg)
           else
             raise MoneyColumn::CurrencyReadOnlyError, msg

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe "Money::Config" do
   describe 'thread safety' do
     it 'does not share the same config across threads' do
       configure(legacy_deprecations: false, default_currency: 'USD') do
-        expect(Money.config.legacy_deprecations).to eq(false)
-        expect(Money.config.default_currency).to eq('USD')
+        expect(Money::Config.current.legacy_deprecations).to eq(false)
+        expect(Money::Config.current.default_currency).to eq('USD')
         thread = Thread.new do
-          Money.config.legacy_deprecations!
-          Money.default_currency = "EUR"
-          expect(Money.config.legacy_deprecations).to eq(true)
-          expect(Money.config.default_currency).to eq("EUR")
+          Money::Config.current.legacy_deprecations!
+          Money::Config.current.default_currency = "EUR"
+          expect(Money::Config.current.legacy_deprecations).to eq(true)
+          expect(Money::Config.current.default_currency).to eq("EUR")
         end
         thread.join
-        expect(Money.config.legacy_deprecations).to eq(false)
-        expect(Money.config.default_currency).to eq('USD')
+        expect(Money::Config.current.legacy_deprecations).to eq(false)
+        expect(Money::Config.current.default_currency).to eq('USD')
       end
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe "Money::Config" do
   describe 'legacy_deprecations' do
     it "respects the default currency" do
       configure(default_currency: 'USD', legacy_deprecations: true) do
-        expect(Money.default_currency).to eq("USD")
+        expect(Money::Config.current.default_currency).to eq("USD")
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "Money::Config" do
 
     it 'legacy_deprecations returns true when opting in to v1' do
       configure(legacy_deprecations: true) do
-        expect(Money.config.legacy_deprecations).to eq(true)
+        expect(Money::Config.current.legacy_deprecations).to eq(true)
       end
     end
 
@@ -45,21 +45,19 @@ RSpec.describe "Money::Config" do
 
     it 'legacy_deprecations defaults to NULL_CURRENCY' do
       configure(legacy_default_currency: true) do
-        expect(Money.config.default_currency).to eq(Money::NULL_CURRENCY)
+        expect(Money::Config.current.default_currency).to eq(Money::NULL_CURRENCY)
       end
     end
   end
 
   describe 'default_currency' do
     it 'defaults to nil' do
-      configure do
-        expect(Money.config.default_currency).to eq(nil)
-      end
+      expect(Money::Config.new.default_currency).to eq(nil)
     end
 
     it 'can be set to a new currency' do
       configure(default_currency: 'USD') do
-        expect(Money.config.default_currency).to eq('USD')
+        expect(Money::Config.current.default_currency).to eq('USD')
       end
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe "Money" do
     end
   end
 
+  it ".configure updates the config" do
+    config_double = instance_double("Money::Config")
+    expect(Money).to receive(:config).and_return(config_double)
+    expect(config_double).to receive(:default_currency=).with('USD')
+    Money.configure { |config| config.default_currency = 'USD' }
+  end
+
   it ".zero has no currency" do
     expect(Money.new(0, Money::NULL_CURRENCY).currency).to be_a(Money::NullCurrency)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,8 +72,7 @@ end
 
 
 def configure(default_currency: nil, legacy_json_format: nil, legacy_deprecations: nil, legacy_default_currency: nil)
-  old_config = Money.config
-  Money.config = Money::Config.new.tap do |config|
+  Money::Config.current = Money::Config.new.tap do |config|
     config.default_currency = default_currency if default_currency
     config.legacy_json_format! if legacy_json_format
     config.legacy_deprecations! if legacy_deprecations
@@ -81,7 +80,7 @@ def configure(default_currency: nil, legacy_json_format: nil, legacy_deprecation
   end
   yield
 ensure
-  Money.config = old_config
+  Money::Config.current = nil
 end
 
 def yaml_load(yaml)


### PR DESCRIPTION
# Why

Help avoid mistakes when setting up configuration. 
After v3.0.1 `Money.default_currency` started only affecting the current thread variable. This can lead to some inconsistencies.

We want all the following syntax to have the same behaviour and all be usable in an initializer file:

```ruby
Money.default_currency = "USD"
Money.configure do |config|
  config.default_currency = "USD"
end
Money.config.default_currency = "USD"
``` 

# What

Move thread specific config to `Money::Config.current`, for example:
```ruby
Money::Config.current.default_currency = "CAD"
```
This current config cannot be used in intializer files as these run in a different current thread as the individual requests.

NOTE: it's preferable to use documented apis rather than `Money::Config.current` directly. For example `Money.with_currency("EUR") { ... }`
