### PR TITLE
Add `experimental_crypto_currencies!` bang method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (3.1.0)
+    shopify-money (3.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -16,6 +16,10 @@ class Money
       @legacy_json_format = true
     end
 
+    def experimental_crypto_currencies!
+      @experimental_crypto_currencies = true
+    end
+
     def initialize
       @default_currency = nil
       @legacy_json_format = false

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -72,7 +72,25 @@ RSpec.describe "Money::Config" do
     it 'can be set to true' do
       config = Money::Config.new
       config.experimental_crypto_currencies = true
+      expect(config.experimental_crypto_currencies).to be(true)
+    end
+
+    it 'can be set to true using the bang method' do
+      config = Money::Config.new
+      config.experimental_crypto_currencies!
       expect(config.experimental_crypto_currencies).to eq(true)
+    end
+  end
+
+  describe 'legacy_json_format' do
+    it 'defaults to false' do
+      expect(Money::Config.new.legacy_json_format).to eq(false)
+    end
+
+    it 'can be set to true using the bang method' do
+      config = Money::Config.new
+      config.legacy_json_format!
+      expect(config.legacy_json_format).to eq(true)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,7 +81,7 @@ def configure(default_currency: nil, legacy_json_format: nil, legacy_deprecation
     config.legacy_json_format! if legacy_json_format
     config.legacy_deprecations! if legacy_deprecations
     config.legacy_default_currency! if legacy_default_currency
-    config.experimental_crypto_currencies = experimental_crypto_currencies unless experimental_crypto_currencies.nil?
+    config.experimental_crypto_currencies! if experimental_crypto_currencies
   end
   yield
 ensure


### PR DESCRIPTION
Add a convenient bang method for enabling experimental cryptocurrency support, similar to other configuration options.

### Changes
* Added `experimental_crypto_currencies!` method to Config for consistency with other configuration options
* Add additional specs for: `legacy_json_format ` and `experimental_crypto_currencies`
* Modified the test helper to use the bang method in the configure wrapper
* Bumped version from 3.1.0 to 3.1.1