### PR TITLE
add stripe subunit override for USDC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (3.1.1)
+    shopify-money (3.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -12,6 +12,7 @@ class Money
     STRIPE_SUBUNIT_OVERRIDE = {
       'ISK' => 100,
       'UGX' => 100,
+      'USDC' => 1_000_000,
     }.freeze
 
     def value_to_decimal(num)

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -457,6 +457,12 @@ RSpec.describe "Money" do
         expect(Money.from_subunits(100, 'UGX', format: :stripe)).to eq(Money.new(1, 'UGX'))
       end
 
+      it 'overrides the subunit_to_unit amount for USDC' do
+        configure(experimental_crypto_currencies: true) do
+          expect(Money.from_subunits(500000, "USDC", format: :stripe)).to eq(Money.new(0.50, 'USDC'))
+        end
+      end
+
       it 'fallbacks to the default subunit_to_unit amount if no override is specified' do
         expect(Money.from_subunits(100, 'USD', format: :stripe)).to eq(Money.new(1, 'USD'))
       end


### PR DESCRIPTION
As discussed on this https://github.com/Shopify/money/pull/398#discussion_r2085182158 we decided we'll use 2 decimals. That being said this PR adds USDC to the stripe subunit override. 