### PR TITLE
Vendor specific subunit converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Money.new(1.00, 'ISK').subunits                    # => 1
 Money.new(1.00, 'ISK').subunits(format: :stripe)   # => 100
 
 # Convert from subunits
-Money.from_subunits(100, 'ISK')                    # => Money.new(1.00, 'USD')
+Money.from_subunits(100, 'ISK')                    # => Money.new(1.00, 'ISK')
 ```
 
 #### Custom Converters

--- a/README.md
+++ b/README.md
@@ -165,6 +165,45 @@ Money.configure do |config|
 end
 ```
 
+### Converters
+The Money gem provides a flexible converter system for handling different subunit formats. This is particularly useful when working with payment providers or APIs that have their own conventions for handling currency subunits.
+
+#### Built-in Converters
+- `:iso4217` (default) - Uses the standard ISO 4217 subunit definitions
+- `:stripe` - Uses Stripe's special cases for certain currencies
+- `:legacy_dollar` - Always uses 100 as the subunit_to_unit value
+
+#### Using Converters
+```ruby
+# Convert to subunits using ISO4217 format (default)
+Money.new(1.00, 'USD').subunits                    # => 100
+Money.new(1.00, 'ISK').subunits                    # => 1
+
+# Convert to subunits using Stripe format
+Money.new(1.00, 'ISK').subunits(format: :stripe)   # => 100
+
+# Convert from subunits
+Money.from_subunits(100, 'ISK')                    # => Money.new(1.00, 'USD')
+```
+
+#### Custom Converters
+You can create your own converter by subclassing `Money::Converters::Converter`:
+
+```ruby
+class MyCustomConverter < Money::Converters::Converter
+  def subunit_to_unit(currency)
+    # Your custom logic here
+    1000
+  end
+end
+
+# Register your converter
+Money::Converters.register(:my_format, MyCustomConverter)
+
+# Use your converter
+Money.new(1.00, 'USD').subunits(format: :my_format) # => 1000
+```
+
 ## Money column
 
 Since money internally uses BigDecimal it's logical to use a `decimal` column

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Money.new(1.00, 'ISK').subunits                    # => 1
 Money.new(1.00, 'ISK').subunits(format: :stripe)   # => 100
 
 # Convert from subunits
-Money.from_subunits(100, 'ISK')                    # => Money.new(1.00, 'ISK')
+Money.from_subunits(100, 'ISK', format: :stripe)                    # => Money.new(1.00, 'ISK')
 ```
 
 #### Custom Converters

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
 require_relative 'money/version'
-require_relative 'money/parser/fuzzy'
-require_relative 'money/helpers'
 require_relative 'money/currency'
 require_relative 'money/null_currency'
 require_relative 'money/allocator'
 require_relative 'money/splitter'
 require_relative 'money/config'
 require_relative 'money/money'
+require_relative 'money/converters/factory'
+require_relative 'money/converters/converter'
+require_relative 'money/converters/iso4217_converter'
+require_relative 'money/converters/stripe_converter'
+require_relative 'money/converters/legacy_dollars_converter'
 require_relative 'money/errors'
 require_relative 'money/deprecations'
+require_relative 'money/parser/fuzzy'
 require_relative 'money/parser/accounting'
-require_relative 'money/parser/locale_aware'
 require_relative 'money/parser/simple'
+require_relative 'money/parser/locale_aware'
+require_relative 'money/helpers'
 require_relative 'money/core_extensions'
 require_relative 'money_column' if defined?(ActiveRecord)
 require_relative 'money/railtie' if defined?(Rails::Railtie)

--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -41,7 +41,7 @@ class Money
       end
     end
 
-    attr_accessor :legacy_json_format, :legacy_deprecations, :experimental_crypto_currencies
+    attr_accessor :legacy_json_format, :legacy_deprecations, :experimental_crypto_currencies, :default_subunit_format
 
     attr_reader :default_currency
     alias_method :currency, :default_currency
@@ -80,6 +80,7 @@ class Money
       @legacy_json_format = false
       @legacy_deprecations = false
       @experimental_crypto_currencies = false
+      @default_subunit_format = :iso4217
     end
   end
 end

--- a/lib/money/converters/converter.rb
+++ b/lib/money/converters/converter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Money
+  module Converters
+    class Converter
+      def to_subunits(money)
+        raise ArgumentError, "money cannot be nil" if money.nil?
+        (money.value * subunit_to_unit(money.currency)).to_i
+      end
+
+      def from_subunits(subunits, currency)
+        currency = Helpers.value_to_currency(currency)
+        value = Helpers.value_to_decimal(subunits) / subunit_to_unit(currency)
+        Money.new(value, currency)
+      end
+
+      protected
+
+      def subunit_to_unit(currency)
+        raise NotImplementedError, "subunit_to_unit method must be implemented in subclasses"
+      end
+    end
+  end
+end

--- a/lib/money/converters/factory.rb
+++ b/lib/money/converters/factory.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Money
+  module Converters
+    class << self
+      def subunit_converters
+        @subunit_converters ||= {}
+      end
+
+      def register(key, klass)
+        subunit_converters[key.to_sym] = klass
+      end
+
+      def for(format)
+        format ||= Money::Config.current.default_subunit_format
+
+        if (klass = subunit_converters[format.to_sym])
+          klass.new
+        else
+          raise(ArgumentError, "unknown format: '#{format}'")
+        end
+      end
+    end
+  end
+end

--- a/lib/money/converters/iso4217_converter.rb
+++ b/lib/money/converters/iso4217_converter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Money
+  module Converters
+    class Iso4217Converter < Converter
+      def subunit_to_unit(currency)
+        currency.subunit_to_unit
+      end
+    end
+  end
+end
+Money::Converters.register(:iso4217, Money::Converters::Iso4217Converter)

--- a/lib/money/converters/legacy_dollars_converter.rb
+++ b/lib/money/converters/legacy_dollars_converter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Money
+  module Converters
+    class LegacyDollarsConverter < Converter
+      def subunit_to_unit(currency)
+        100
+      end
+    end
+  end
+end
+Money::Converters.register(:legacy_dollar, Money::Converters::LegacyDollarsConverter)

--- a/lib/money/converters/stripe_converter.rb
+++ b/lib/money/converters/stripe_converter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Money
+  module Converters
+    class StripeConverter < Iso4217Converter
+      SUBUNIT_TO_UNIT = {
+        # https://docs.stripe.com/currencies#special-cases
+        'ISK' => 100,
+        'UGX' => 100,
+        'HUF' => 100,
+        'TWD' => 100,
+        # https://docs.stripe.com/currencies#zero-decimal
+        'BIF' => 1,
+        'CLP' => 1,
+        'DJF' => 1,
+        'GNF' => 1,
+        'JPY' => 1,
+        'KMF' => 1,
+        'KRW' => 1,
+        'MGA' => 1,
+        'PYG' => 1,
+        'RWF' => 1,
+        'VND' => 1,
+        'VUV' => 1,
+        'XAF' => 1,
+        'XOF' => 1,
+        'XPF' => 1,
+        'USDC' => 1_000_000,
+      }.freeze
+
+      def subunit_to_unit(currency)
+        SUBUNIT_TO_UNIT.fetch(currency.iso_code, super)
+      end
+    end
+  end
+end
+Money::Converters.register(:stripe, Money::Converters::StripeConverter)

--- a/lib/money/helpers.rb
+++ b/lib/money/helpers.rb
@@ -9,12 +9,6 @@ class Money
     DECIMAL_ZERO = BigDecimal(0).freeze
     MAX_DECIMAL = 21
 
-    STRIPE_SUBUNIT_OVERRIDE = {
-      'ISK' => 100,
-      'UGX' => 100,
-      'USDC' => 1_000_000,
-    }.freeze
-
     def value_to_decimal(num)
       value =
         case num

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -87,19 +87,8 @@ class Money
     end
     alias_method :from_amount, :new
 
-    def from_subunits(subunits, currency_iso, format: :iso4217)
-      currency = Helpers.value_to_currency(currency_iso)
-
-      subunit_to_unit_value = if format == :iso4217
-        currency.subunit_to_unit
-      elsif format == :stripe
-        Helpers::STRIPE_SUBUNIT_OVERRIDE.fetch(currency.iso_code, currency.subunit_to_unit)
-      else
-        raise ArgumentError, "unknown format #{format}"
-      end
-
-      value = Helpers.value_to_decimal(subunits) / subunit_to_unit_value
-      new(value, currency)
+    def from_subunits(subunits, currency_iso, format: nil)
+      Converters.for(format).from_subunits(subunits, currency_iso)
     end
 
     def from_json(string)
@@ -160,16 +149,8 @@ class Money
     coder['currency'] = @currency.iso_code
   end
 
-  def subunits(format: :iso4217)
-    subunit_to_unit_value = if format == :iso4217
-      @currency.subunit_to_unit
-    elsif format == :stripe
-      Helpers::STRIPE_SUBUNIT_OVERRIDE.fetch(@currency.iso_code, @currency.subunit_to_unit)
-    else
-      raise ArgumentError, "unknown format #{format}"
-    end
-
-    (@value * subunit_to_unit_value).to_i
+  def subunits(format: nil)
+    Converters.for(format).to_subunits(self)
   end
 
   def no_currency?

--- a/spec/converters_spec.rb
+++ b/spec/converters_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Money::Converters do
+  let(:usd) { Money::Currency.find!('USD') }
+  let(:ugx) { Money::Currency.find!('UGX') }
+
+  describe '.for' do
+    it 'returns Iso4217Converter for :iso4217' do
+      expect(Money::Converters.for(:iso4217)).to be_a(Money::Converters::Iso4217Converter)
+    end
+
+    it 'returns StripeConverter for :stripe' do
+      expect(Money::Converters.for(:stripe)).to be_a(Money::Converters::StripeConverter)
+    end
+
+    it 'returns LegacyDollarsConverter for :legacy_dollar' do
+      expect(Money::Converters.for(:legacy_dollar)).to be_a(Money::Converters::LegacyDollarsConverter)
+    end
+
+    it 'raises ArgumentError for unknown format' do
+      expect { Money::Converters.for(:unknown) }.to raise_error(ArgumentError, /unknown format/)
+    end
+  end
+
+  describe 'registering a custom converter' do
+    class DummyConverter < Money::Converters::Converter
+      def subunit_to_unit(currency); 42; end
+    end
+
+    class InvalidConverter < Money::Converters::Converter
+      # Intentionally not implementing subunit_to_unit
+    end
+
+    after { Money::Converters.subunit_converters.delete(:dummy) }
+
+    it 'registers and uses a custom converter' do
+      Money::Converters.register(:dummy, DummyConverter)
+      converter = Money::Converters.for(:dummy)
+      expect(converter).to be_a(DummyConverter)
+      expect(converter.to_subunits(Money.new(1, 'USD'))).to eq(42)
+    end
+
+    it 'raises NotImplementedError when subunit_to_unit is not implemented' do
+      Money::Converters.register(:invalid, InvalidConverter)
+      converter = Money::Converters.for(:invalid)
+      expect { converter.to_subunits(Money.new(1, 'USD')) }.to raise_error(NotImplementedError, "subunit_to_unit method must be implemented in subclasses")
+    end
+  end
+
+  describe Money::Converters::Iso4217Converter do
+    let(:converter) { described_class.new }
+    it 'uses currency.subunit_to_unit' do
+      expect(converter.to_subunits(Money.new(1, usd))).to eq(100)
+      expect(converter.from_subunits(100, usd)).to eq(Money.new(1, usd))
+    end
+  end
+
+  describe Money::Converters::StripeConverter do
+    let(:converter) { described_class.new }
+
+    it 'uses Stripe special cases' do
+      expect(converter.to_subunits(Money.new(1, ugx))).to eq(100)
+      expect(converter.from_subunits(100, ugx)).to eq(Money.new(1, ugx))
+      expect(converter.to_subunits(Money.new(1, usd))).to eq(100)
+      expect(converter.from_subunits(100, usd)).to eq(Money.new(1, usd))
+    end
+
+    it 'handles USDC if present' do
+      configure(experimental_crypto_currencies: true) do
+        expect(converter.to_subunits(Money.new(1, "usdc"))).to eq(1_000_000)
+        expect(converter.from_subunits(1_000_000, "usdc")).to eq(Money.new(1, "usdc"))
+      end
+    end
+  end
+
+  describe Money::Converters::LegacyDollarsConverter do
+    let(:converter) { described_class.new }
+    it 'always uses 100 as subunit_to_unit' do
+      expect(converter.to_subunits(Money.new(1, usd))).to eq(100)
+      expect(converter.from_subunits(100, usd)).to eq(Money.new(1, usd))
+    end
+  end
+end


### PR DESCRIPTION
## Why

Some 3rd party vendors have their own units (dollars) to subunits (cents) definitions that can be different from this gem's currency definitions. For example, Stripe has multiple "[special cases](https://docs.stripe.com/currencies#special-cases)" which do not match with the ISO standards. Right now the gems has a patch just for Stripe, which should be removed and replaced with something that can be used for any vendor

## What

Add the ability to create custom converters. Out of the box the Money gem will come with :stripe and :legacy_dollar for backward compatibility

```ruby
class StripeSubunitConverter < Iso4217SubunitConverter
      STRIPE_ZERO_DECIMAL_OVERRIDE = ...
      def subunit_to_unit(currency)
        STRIPE_ZERO_DECIMAL_OVERRIDE.fetch(currency.iso_code, super)
      end
end

Money::Converters.register(:stripe, StripeSubunitConverter)

# Money.from_subunits("1200", "TWD", format: :stripe) #=> Money.new(12, "TWD")
# Money.new(12, "TWD").subunits(format: :stripe) #=> 1200
```