### PR TITLE
Add missing `require`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (3.2.1)
+    shopify-money (3.2.2)
       bigdecimal (>= 3.0)
 
 GEM

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'delegate'
+require 'bigdecimal'
 
 class Money
   class Allocator < SimpleDelegator

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
Fixes crash when used in a context where `bigdecimal` wasn't already required.

```
Error: bundler: failed to load command: tapioca (/Users/alex/.gem/ruby/3.4.3/bin/tapioca)
/Users/alex/.gem/ruby/3.4.3/gems/shopify-money-3.2.1/lib/money/allocator.rb:11:in '<class:Allocator>': undefined method 'BigDecimal' for class Money::Allocator (NoMethodError)

    ONE = BigDecimal("1")
          ^^^^^^^^^^
	from /Users/alex/.gem/ruby/3.4.3/gems/shopify-money-3.2.1/lib/money/allocator.rb:6:in '<class:Money>'
```