### PR TITLE
Fix issue when formatting error message for read-only currencies

### DIFF
--- a/lib/money_column/active_record_hooks.rb
+++ b/lib/money_column/active_record_hooks.rb
@@ -58,6 +58,7 @@ module MoneyColumn
 
       if options[:currency_read_only]
         unless compatible_currency?(money, options)
+          currency = options[:currency] || try(options[:currency_column])
           msg = "Cannot update #{column}: Attempting to write a money with currency #{money.currency} to a record with currency #{currency}. If you do want to change the currency, either remove `currency_read_only` or update the record's currency manually"
           if Money::Config.current.legacy_deprecations
             Money.deprecate(msg)


### PR DESCRIPTION
Fix issue when formatting error message for read-only currencies.

This issue was introduced in #409. The error message references the `currency` variable (`"... to a record with currency #{currency}. ..."`), however there is no guarantee that `currency` is a valid variable or method name on the ActiveRecord class.

If it is not, then the code will produce a `NameError` with message "undefined local variable or method 'currency' for an instance of RecordClass".

I wanted to add a test for this, but the schema used in the gem's tests defines a single `money_records` table shared for all test models, and it does have a `currency` column so it won't trigger the bug above, and I don't think this issue warrants defining a separate table.
