### PR TITLE
Bump version to 3.2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (3.2.3)
+    shopify-money (3.2.4)
       bigdecimal (>= 3.0)
 
 GEM

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "3.2.3"
+  VERSION = "3.2.4"
 end


### PR DESCRIPTION
## What's Changed
* [Bugfix] issue when formatting error message for read-only currencies. by @elfassy in https://github.com/Shopify/money/pull/425


**Full Changelog**: https://github.com/Shopify/money/compare/v3.2.3...v3.2.4