### PR TITLE
Fix private klass method warning

### DIFF
--- a/lib/money/rails/job_argument_serializer.rb
+++ b/lib/money/rails/job_argument_serializer.rb
@@ -11,8 +11,6 @@ class Money
         Money.new(hash["value"], hash["currency"])
       end
 
-      private
-
       def klass
         Money
       end


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/55583, we warn if the klass method is not public.

Related to https://github.com/shop/issues-rails-infrastructure/issues/1025.