### PR TITLE
Make klass method public

### DIFF
--- a/lib/money/rails/job_argument_serializer.rb
+++ b/lib/money/rails/job_argument_serializer.rb
@@ -11,6 +11,7 @@ class Money
         Money.new(hash["value"], hash["currency"])
       end
 
+      # Rails now expects this method to be public
       def klass
         Money
       end


### PR DESCRIPTION
Rails now expects this method to be public, this is failing the Rails upgrade in core