### PR TITLE
Delegate `Money#clamp` to `Comparable#clamp`

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -348,15 +348,14 @@ class Money
   #
   # @example
   #   Money.new(50, "CAD").clamp(1, 100) #=> Money.new(50, "CAD")
+  #   Money.new(50, "CAD").clamp(1..100) #=> Money.new(50, "CAD")
+  #   Money.new(50, "CAD").clamp(1, nil) #=> Money.new(1,  "CAD")
   #
   #   Money.new(120, "CAD").clamp(0, 100) #=> Money.new(100, "CAD")
-  def clamp(min, max)
-    raise ArgumentError, 'min cannot be greater than max' if min > max
+  def clamp(...)
+    clamped_value = value.clamp(...)
 
-    clamped_value = min if value < min
-    clamped_value = max if value > max
-
-    if clamped_value.nil?
+    if clamped_value == value
       self
     else
       Money.new(clamped_value, currency)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1144,6 +1144,18 @@ RSpec.describe "Money" do
     let(:min) { -max }
 
     it 'returns the same value if the value is within the min..max range' do
+      money = Money.new(5000, 'EUR').clamp(min..max)
+      expect(money.value).to eq(5000)
+      expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'returns the same value if the value is larger and the max value is nil' do
+      money = Money.new(min + 1, 'EUR').clamp(min, nil)
+      expect(money.value).to eq(min + 1)
+      expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'returns the same value if the value is between the min and max' do
       money = Money.new(5000, 'EUR').clamp(min, max)
       expect(money.value).to eq(5000)
       expect(money.currency.iso_code).to eq('EUR')
@@ -1159,6 +1171,17 @@ RSpec.describe "Money" do
       money = Money.new(-9001, 'EUR').clamp(min, max)
       expect(money.value).to eq(-9000)
       expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'returns the min value if the original value is smaller and the max value is nil' do
+      money = Money.new(min - 1, 'EUR').clamp(min, nil)
+      expect(money.value).to eq(min)
+      expect(money.currency.iso_code).to eq('EUR')
+    end
+
+    it 'raises an Argument error if the max value is less than the min value' do
+      money = Money.new(-9001, 'EUR').clamp(min, nil)
+      expect { money.clamp(max, min) }.to raise_error(ArgumentError, 'min argument must be less than or equal to max argument')
     end
   end
 


### PR DESCRIPTION
The [Comparable#clamp][] interface supports two additional styles of invocation that `Money#clamp` does not:

* a [Range][] instance
* a `nil` maximum

To support those invocations, this commit uses the `...` argument forwarding syntax to pass along any arguments to the underlying `#clamp` implementation.

To ensure that the `ArgumentError` is still raised, this commit introduces test coverage. The prior error's message (`min cannot be greater than max`) is replaced with the message provided by the standard library (`min argument must be less than or equal to max argument`).

[Comparable#clamp]: https://docs.ruby-lang.org/en/master/Comparable.html#method-i-clamp
[Range]: https://docs.ruby-lang.org/en/master/Range.html