### PR TITLE
perf: skip redundant currency resolution in `Money#initialize`

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -128,13 +128,16 @@ class Money
     raise ArgumentError if value.nan?
     raise ArgumentError if value.infinite?
 
-    @currency = Helpers.value_to_currency(currency)
+    @currency = currency
     @value = BigDecimal(value.round(@currency.minor_units))
     freeze
   end
 
   def init_with(coder)
-    initialize(Helpers.value_to_decimal(coder['value']), coder['currency'])
+    initialize(
+      Helpers.value_to_decimal(coder['value']),
+      Helpers.value_to_currency(coder['currency']),
+    )
   end
 
   def encode_with(coder)


### PR DESCRIPTION
## Summary

`Money.new` resolves the currency via `Helpers.value_to_currency` before calling `initialize`, but `initialize` called `value_to_currency` again on the already-resolved `Currency` object. This removes the redundant call. `init_with` (YAML deserialization) is updated to resolve before calling `initialize`.

~4% faster for string currency codes, ~6% faster for Currency objects.

<details>
<summary>Benchmark (2M iterations of <code>Money.new</code>)</summary>

```rb
require "money"
require "benchmark"

n = 2_000_000
c = Money::Currency.find!("USD")

Benchmark.bm do |x|
  x.report("string") { n.times { Money.new(100, "USD") } }
  x.report("currency") { n.times { Money.new(100, c) } }
end
```

### Main

```
              user     system      total        real
string    1.840458   0.004621   1.845079 (  1.845461)
currency  1.354037   0.002053   1.356090 (  1.356246)
```

### This branch

```
              user     system      total        real
string    1.772362   0.002751   1.775113 (  1.775356)
currency  1.267099   0.002948   1.270047 (  1.270183)
```

</details>