### PR TITLE
perf: skip redundant `downcase` in `Currency.find!` on cache hits

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -11,9 +11,13 @@ class Money
 
     class << self
       def new(currency_iso)
-        raise UnknownCurrency, "Currency can't be blank" if currency_iso.nil? || currency_iso.to_s.empty?
-        iso = currency_iso.to_s.downcase
-        @@loaded_currencies[iso] || @@mutex.synchronize { @@loaded_currencies[iso] = super(iso) }
+        iso = currency_iso.to_s
+        return @@loaded_currencies[iso] if @@loaded_currencies.key?(iso)
+        raise UnknownCurrency, "Currency can't be blank" if iso.empty?
+        downcased = iso.downcase
+        @@mutex.synchronize do
+          @@loaded_currencies[iso] ||= @@loaded_currencies[downcased] ||= super(downcased)
+        end
       end
       alias_method :find!, :new
 


### PR DESCRIPTION
## Summary

Optimize `Currency.find!` (aliased from `Currency.new`) to skip `to_s.downcase` on cache hits. On the first resolution of a currency string (e.g. `"USD"`), the result is stored under both the original-case and downcased keys in `@@loaded_currencies`. Subsequent lookups hit the fast path immediately without allocating a downcased string or checking the mutex.

Stacks on #520.

<details>
<summary>Benchmark (2M iterations of <code>Money.new</code>)</summary>

```rb
require "money"
require "benchmark"

n = 2_000_000
c = Money::Currency.find!("USD")

Benchmark.bm do |x|
  x.report("string") { n.times { Money.new(100, "USD") } }
  x.report("currency") { n.times { Money.new(100, c) } }
end
```

### main

```
              user     system      total        real
string    1.801176   0.008822   1.809998 (  1.942647)
currency  1.305507   0.004958   1.310465 (  1.423729)
```

### #520 (base branch)

```
              user     system      total        real
string    1.735361   0.005490   1.740851 (  1.860185)
currency  1.237422   0.003729   1.241151 (  1.351668)
```

### This branch

```
              user     system      total        real
string    1.618875   0.007278   1.626153 (  1.797001)
currency  1.200702   0.005228   1.205930 (  1.378954)
```

### Summary

```
                    main → #520      #520 → this     main → this
string              ~4%              ~7%              ~10%
currency            ~5%              ~3%              ~8%
```

</details>