### PR TITLE
Fix float imprecision in allocate and add configurable strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ Money.new(money.value * exchange_rate, "JPY")
 money.convert_currency(exchange_rate, "JPY")
 ```
 
+### Allocation Strategy
+
+By default `allocate` distributes leftover subunits using the `:roundrobin` strategy.
+You can change the default:
+
+``` ruby
+Money.configure do |config|
+  config.default_allocation_strategy = :nearest
+end
+```
+
+Or pass a strategy per call:
+
+``` ruby
+Money.new(10.55, "USD").allocate([0.25, 0.5, 0.25], :nearest)
+```
+
 ### Crypto Currencies
 To enable support for currencies listed in `crypto.yml` use
 ``` ruby

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -62,7 +62,9 @@ class Money
         raise ArgumentError, 'at least one split must be provided'
       end
 
-      splits.map!(&:to_r)
+      # Float#to_r preserves float imprecision (0.98.to_r != 98/100).
+      # Rationalize gives the clean fraction (0.98.rationalize == 49/50).
+      splits.map!(&:rationalize)
       allocations = splits.inject(0, :+)
 
       if (allocations - ONE) > Float::EPSILON

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -33,6 +33,8 @@ class Money
     # - `:roundrobin_reverse`: leftover subunits will be accumulated starting from the last allocation right to left
     # - `:nearest`: leftover subunits will by given first to the party closest to the next whole subunit
     #
+    # The default strategy can be changed via `Money::Config.current.default_allocation_strategy`.
+    #
     # @example
     #   Money.new(5, "USD").allocate([0.50, 0.25, 0.25])
     #     #=> [#<Money value:2.50 currency:USD>, #<Money value:1.25 currency:USD>, #<Money value:1.25 currency:USD>]
@@ -57,10 +59,12 @@ class Money
     #   Money.new(10.55, "USD").allocate([0.25, 0.5, 0.25], :nearest)
     #     #=> [#<Money value:2.64 currency:USD>, #<Money value:5.27 currency:USD>, #<Money value:2.64 currency:USD>]
 
-    def allocate(splits, strategy = :roundrobin)
+    def allocate(splits, strategy = nil)
       if splits.empty?
         raise ArgumentError, 'at least one split must be provided'
       end
+
+      strategy ||= Money::Config.current.default_allocation_strategy
 
       # Float#to_r preserves float imprecision (0.98.to_r != 98/100).
       # Rationalize gives the clean fraction (0.98.rationalize == 49/50).

--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -41,7 +41,7 @@ class Money
       end
     end
 
-    attr_accessor :legacy_json_format, :experimental_crypto_currencies, :default_subunit_format, :experimental_custom_currency_path
+    attr_accessor :legacy_json_format, :experimental_crypto_currencies, :default_subunit_format, :experimental_custom_currency_path, :default_allocation_strategy
 
     attr_reader :default_currency
     alias_method :currency, :default_currency
@@ -73,6 +73,7 @@ class Money
       @experimental_crypto_currencies = false
       @default_subunit_format = :iso4217
       @experimental_custom_currency_path = nil
+      @default_allocation_strategy = :roundrobin
     end
   end
 end

--- a/sig/money/config.rbs
+++ b/sig/money/config.rbs
@@ -8,6 +8,7 @@ class Money
     attr_accessor experimental_crypto_currencies: bool
     attr_accessor default_subunit_format: Symbol
     attr_accessor experimental_custom_currency_path: String?
+    attr_accessor default_allocation_strategy: Symbol
 
     attr_reader default_currency: (Currency | NullCurrency | nil)
     def default_currency=: (String | Currency | NullCurrency | nil value) -> (Currency | NullCurrency | nil)
@@ -17,7 +18,7 @@ class Money
     def self.global: () -> Config
     def self.current: () -> Config
     def self.current=: (Config config) -> Config
-    def self.configure_current: [T] (?currency: (String | Currency | NullCurrency | nil), ?legacy_json_format: bool, ?experimental_crypto_currencies: bool, ?default_subunit_format: Symbol, ?experimental_custom_currency_path: String?) { () -> T } -> T
+    def self.configure_current: [T] (?currency: (String | Currency | NullCurrency | nil), ?legacy_json_format: bool, ?experimental_crypto_currencies: bool, ?default_subunit_format: Symbol, ?experimental_custom_currency_path: String?, ?default_allocation_strategy: Symbol) { () -> T } -> T
     def self.reset_current: () -> nil
 
     private

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Allocator" do
 
     specify "#allocate will use rationals if provided" do
       splits = [128400,20439,14589,14589,25936].map{ |num| Rational(num, 203953) } # sums to > 1 if converted to float
-      expect(new_allocator(2.25).allocate(splits)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
+      expect(new_allocator(2.25).allocate(splits, :roundrobin)).to eq([Money.new(1.42), Money.new(0.23), Money.new(0.16), Money.new(0.16), Money.new(0.28)])
     end
 
     specify "#allocate will convert rationals with high precision" do
@@ -59,6 +59,23 @@ RSpec.describe "Allocator" do
 
     specify "#allocate raise ArgumentError when invalid strategy is provided" do
       expect { new_allocator(0.03).allocate([0.5, 0.5], :bad_strategy_name) }.to raise_error(ArgumentError, "Invalid strategy. Valid options: :roundrobin, :roundrobin_reverse, :nearest")
+    end
+
+    specify "#allocate defaults to :nearest strategy" do
+      # With :nearest, the party closest to the next whole subunit gets the leftover.
+      monies = new_allocator(1).allocate([0.02, 0.98])
+      expect(monies[0]).to eq(Money.new(0.02))
+      expect(monies[1]).to eq(Money.new(0.98))
+    end
+
+    specify "#allocate uses the configured default_allocation_strategy" do
+      Money.with_config(default_allocation_strategy: :roundrobin) do
+        # With :roundrobin, leftover subunits accumulate from the first allocation.
+        monies = new_allocator(0.05).allocate([0.33, 0.34, 0.33])
+        expect(monies[0]).to eq(Money.new(0.02))
+        expect(monies[1]).to eq(Money.new(0.02))
+        expect(monies[2]).to eq(Money.new(0.01))
+      end
     end
 
     specify "#allocate exact splits produce no leftover regardless of strategy" do

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe "Allocator" do
       expect { new_allocator(0.03).allocate([0.5, 0.5], :bad_strategy_name) }.to raise_error(ArgumentError, "Invalid strategy. Valid options: :roundrobin, :roundrobin_reverse, :nearest")
     end
 
+    specify "#allocate exact splits produce no leftover regardless of strategy" do
+      monies = new_allocator(1).allocate([0.02, 0.98], :roundrobin)
+      expect(monies[0]).to eq(Money.new(0.02))
+      expect(monies[1]).to eq(Money.new(0.98))
+    end
+
     specify "#allocate raises an error when splits exceed 100%" do
       expect { new_allocator(0.03).allocate([0.5, 0.6]) }.to raise_error(ArgumentError, "allocations add to more than 100%")
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe "Money::Config" do
     end
   end
 
+  describe 'default_allocation_strategy' do
+    it 'defaults to :roundrobin' do
+      expect(Money::Config.new.default_allocation_strategy).to eq(:roundrobin)
+    end
+
+    it 'can be set to a different strategy' do
+      config = Money::Config.new
+      config.default_allocation_strategy = :roundrobin
+      expect(config.default_allocation_strategy).to eq(:roundrobin)
+    end
+  end
+
   describe 'legacy_json_format' do
     it 'defaults to false' do
       expect(Money::Config.new.legacy_json_format).to eq(false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,12 +75,13 @@ RSpec::Matchers.define :quack_like do
 end
 
 
-def configure(default_currency: nil, legacy_json_format: nil, experimental_crypto_currencies: nil, experimental_custom_currency_path: nil)
+def configure(default_currency: nil, legacy_json_format: nil, experimental_crypto_currencies: nil, experimental_custom_currency_path: nil, default_allocation_strategy: nil)
   Money::Config.current = Money::Config.new.tap do |config|
     config.default_currency = default_currency if default_currency
     config.legacy_json_format! if legacy_json_format
     config.experimental_crypto_currencies = experimental_crypto_currencies unless experimental_crypto_currencies.nil?
     config.experimental_custom_currency_path = experimental_custom_currency_path if experimental_custom_currency_path
+    config.default_allocation_strategy = default_allocation_strategy if default_allocation_strategy
   end
 
   yield


### PR DESCRIPTION
# Why

Bug
```ruby
Money::Allocator.new(Money.new(100, "USD")).allocate([0.02, 0.98])
=> [#<Money value:2.01 currency:USD>, #<Money value:97.99 currency:USD>]
```

After
```ruby
Money::Allocator.new(Money.new(100, "USD")).allocate([0.02, 0.98])
=> [#<Money value:2.00 currency:USD>, #<Money value:98.00 currency:USD>]
```

# What

```
> 0.98.to_r == Rational(98, 100)
=> false
```
this is because floats have errors that get carried into the rational. 
```
0.98.to_r  #=> (2206763817411543/2251799813685248)  # slightly less than 0.98!
```

Option1: `0.98.to_s.to_r #=> (98/100)`
Option2: `0.98.rationalize #=> (98/100)`

- fix the bug, went with option 2 which gets us better performance
- Allow setting the strategy at the app level: `config.default_allocation_strategy = :roundrobin`