### PR TITLE
allocations support for BigDecimal 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-money (4.1.0)
+    shopify-money (4.1.1)
       bigdecimal (>= 3.0)
 
 GEM

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -185,12 +185,10 @@ class Money
     end
 
     def rationalize(number)
-      if number.is_a?(Float)
-        # Float#to_r preserves float imprecision (0.98.to_r != 49/50).
-        number.rationalize
-      else
-        number.to_r
-      end
+      return number if number.is_a?(Rational)
+
+      # Float#to_r preserves float imprecision (0.98.to_r != 49/50).
+      number.to_s.to_r
     end
   end
 end

--- a/lib/money/allocator.rb
+++ b/lib/money/allocator.rb
@@ -66,9 +66,7 @@ class Money
 
       strategy ||= Money::Config.current.default_allocation_strategy
 
-      # Float#to_r preserves float imprecision (0.98.to_r != 98/100).
-      # Rationalize gives the clean fraction (0.98.rationalize == 49/50).
-      splits.map!(&:rationalize)
+      splits.map! { |split| rationalize(split) }
       allocations = splits.inject(0, :+)
 
       if (allocations - ONE) > Float::EPSILON
@@ -184,6 +182,15 @@ class Money
     # is because 3.9 is nearer to 4 than 9.1 is to 10.
     def rank_by_nearest(amounts)
       amounts.each_with_index.sort_by { |amount, _i| 1 - amount[:fractional_subunits] }.map(&:last)
+    end
+
+    def rationalize(number)
+      if number.is_a?(Float)
+        # Float#to_r preserves float imprecision (0.98.to_r != 49/50).
+        number.rationalize
+      else
+        number.to_r
+      end
     end
   end
 end

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Money
-  VERSION = "4.1.0"
+  VERSION = "4.1.1"
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -301,6 +301,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: prism
+  version: 1.9.0
+  source:
+    type: rubygems
 - name: pstore
   version: '0'
   source:

--- a/sig/money/allocator.rbs
+++ b/sig/money/allocator.rbs
@@ -27,5 +27,6 @@ class Money
     def amounts_from_splits: (Numeric allocations, Array[Numeric] splits, ?Integer subunits_to_split) -> [Array[Hash[Symbol, Numeric]], Integer]
     def all_rational?: (Array[Numeric] splits) -> bool
     def rank_by_nearest: (Array[Hash[Symbol, Numeric]] amounts) -> Array[Integer]
+    def rationalize: (Numeric number) -> Rational
   end
 end

--- a/spec/allocator_spec.rb
+++ b/spec/allocator_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe "Allocator" do
       expect { new_allocator(1).allocate([rate, 1 - rate]) }.not_to raise_error
     end
 
+    specify "#allocate handles BigDecimal splits" do
+      splits = [BigDecimal("0.25"), BigDecimal("0.75")]
+      expect(new_allocator(10).allocate(splits)).to eq([Money.new(2.50), Money.new(7.50)])
+    end
+
+    specify "#allocate handles Float splits" do
+      splits = [0.25, 0.75]
+      expect(new_allocator(10).allocate(splits)).to eq([Money.new(2.50), Money.new(7.50)])
+    end
+
+    specify "#allocate handles Rational splits" do
+      splits = [Rational(1, 4), Rational(3, 4)]
+      expect(new_allocator(10).allocate(splits)).to eq([Money.new(2.50), Money.new(7.50)])
+    end
+
+
     specify "#allocate raise ArgumentError when invalid strategy is provided" do
       expect { new_allocator(0.03).allocate([0.5, 0.5], :bad_strategy_name) }.to raise_error(ArgumentError, "Invalid strategy. Valid options: :roundrobin, :roundrobin_reverse, :nearest")
     end


### PR DESCRIPTION
# Why

Previous [release](https://github.com/Shopify/money/pull/522) broke support for allocate with BigDecimal (allocate should accept any Numeric). BigDecimal does not have a `rationalize` method

`rationalize` isn't defined on Numeric — it's individually implemented on `Float`, `Integer`, and `Rational` as separate C-level methods. There's no shared Numeric#rationalize that subclasses inherit. It's a convention those three classes happen to follow, not a contract Numeric enforces.

# What

only Floats use `rationalize`, everyone else uses `to_r`. The alternative is using `to_s.to_r` for everyone