### PR TITLE
Expose Currency#thousands_separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ currency.name     #=> "United States Dollar"
 currency.to_s     #=> 'USD'
 currency.symbol   #=> '$'
 currency.disambiguate_symbol #=> 'US$'
+currency.decimal_mark #=> '.'
+currency.thousands_separator #=> ','
 ```
 
 ### Default Currency
@@ -200,6 +202,7 @@ credits:
   subunit_to_unit: 1
   smallest_denomination: 1
   decimal_mark: "."
+  thousands_separator: ","
 ```
 
 Custom currencies are looked up after ISO and crypto currencies, so they cannot shadow built-in currencies.

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -54,7 +54,8 @@ class Money
       :minor_units,
       :symbol,
       :disambiguate_symbol,
-      :decimal_mark
+      :decimal_mark,
+      :thousands_separator
 
     def initialize(currency_iso)
       data = self.class.currencies[currency_iso]
@@ -76,6 +77,7 @@ class Money
       @smallest_denomination = data['smallest_denomination']
       @subunit_to_unit       = data['subunit_to_unit']
       @decimal_mark          = data['decimal_mark']
+      @thousands_separator   = data['thousands_separator']
       @minor_units           = subunit_to_unit == 0 ? 0 : Math.log(subunit_to_unit, 10).round.to_i
       freeze
     end

--- a/lib/money/null_currency.rb
+++ b/lib/money/null_currency.rb
@@ -42,7 +42,8 @@ class Money
       :minor_units,
       :symbol,
       :disambiguate_symbol,
-      :decimal_mark
+      :decimal_mark,
+      :thousands_separator
 
     def initialize
       @symbol                = '$'
@@ -54,6 +55,7 @@ class Money
       @subunit_to_unit       = 100
       @minor_units           = 2
       @decimal_mark          = '.'
+      @thousands_separator   = ','
       freeze
     end
 

--- a/sig/money/currency.rbs
+++ b/sig/money/currency.rbs
@@ -24,6 +24,7 @@ class Money
     attr_reader symbol: String
     attr_reader disambiguate_symbol: String
     attr_reader decimal_mark: String
+    attr_reader thousands_separator: String
 
     # self.new overrides Class#new and calls super(iso) which goes to initialize
     def self.new: (String | Symbol currency_iso) -> Currency

--- a/sig/money/null_currency.rbs
+++ b/sig/money/null_currency.rbs
@@ -12,6 +12,7 @@ class Money
     attr_reader symbol: String
     attr_reader disambiguate_symbol: String?
     attr_reader decimal_mark: String
+    attr_reader thousands_separator: String
 
     def initialize: () -> void
     def compatible?: (untyped other) -> bool

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe Money::Currency::Loader do
           "disambiguate_symbol" => "CR",
           "subunit_to_unit" => 1,
           "smallest_denomination" => 1,
-          "decimal_mark" => "."
+          "decimal_mark" => ".",
+          "thousands_separator" => ","
         }
       )
 
@@ -58,6 +59,7 @@ RSpec.describe Money::Currency::Loader do
       expect(currencies['credits']['name']).to eq('Loyalty Points')
       expect(currencies['credits']['symbol']).to eq('CR')
       expect(currencies['credits']['subunit_to_unit']).to eq(1)
+      expect(currencies['credits']['thousands_separator']).to eq(',')
     ensure
       file.unlink
     end
@@ -77,7 +79,8 @@ RSpec.describe Money::Currency::Loader do
           "disambiguate_symbol" => "CR",
           "subunit_to_unit" => 1,
           "smallest_denomination" => 1,
-          "decimal_mark" => "."
+          "decimal_mark" => ".",
+          "thousands_separator" => ","
         }
       )
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Currency" do
     "symbol": '$',
     "disambiguate_symbol": "US$",
     "decimal_mark": ".",
+    "thousands_separator": ",",
   }
 
   let(:currency) { Money::Currency.new('usd') }
@@ -26,7 +27,8 @@ RSpec.describe "Currency" do
         "disambiguate_symbol" => "CR",
         "subunit_to_unit" => 1,
         "smallest_denomination" => 1,
-        "decimal_mark" => "."
+        "decimal_mark" => ".",
+        "thousands_separator" => ","
       }
     }
   end
@@ -40,7 +42,8 @@ RSpec.describe "Currency" do
         "disambiguate_symbol" => "USDC",
         "subunit_to_unit" => 100,
         "smallest_denomination" => 1,
-        "decimal_mark" => "."
+        "decimal_mark" => ".",
+        "thousands_separator" => ","
       } 
     }
   end
@@ -109,7 +112,8 @@ RSpec.describe "Currency" do
           "disambiguate_symbol" => "FAKE",
           "subunit_to_unit" => 1,
           "smallest_denomination" => 1,
-          "decimal_mark" => "."
+          "decimal_mark" => ".",
+          "thousands_separator" => ","
         }
       )
 
@@ -131,7 +135,8 @@ RSpec.describe "Currency" do
           "disambiguate_symbol" => "FAKE",
           "subunit_to_unit" => 1,
           "smallest_denomination" => 1,
-          "decimal_mark" => "."
+          "decimal_mark" => ".",
+          "thousands_separator" => ","
         }
       )
 

--- a/spec/null_currency_spec.rb
+++ b/spec/null_currency_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "NullCurrency" do
       expect(null_currency.symbol).to eq('$')
       expect(null_currency.subunit_to_unit).to eq(100)
       expect(null_currency.smallest_denomination).to eq(1)
+      expect(null_currency.thousands_separator).to eq(',')
     end
 
     it "has the name No Currency" do


### PR DESCRIPTION
## Why

Currency data already includes `thousands_separator`, but `Money::Currency` only exposed `decimal_mark`. Callers that need currency-aware formatting currently have to reach back into `Money::Currency.currencies` even though the loaded currency object already represents the same data.

## What changed

- Expose `Money::Currency#thousands_separator` from the loaded currency data.
- Keep `Money::NullCurrency` quacking like `Money::Currency` by exposing the same reader with the USD-style delimiter.
- Update RBS signatures, docs, and currency specs.

## Formatting note

I also checked for a higher-level formatter. The gem currently exposes `Money#to_s` / `Money#to_fs`, but those return the numeric amount string only. They do not include currency symbols, thousands delimiters, or Rails-style `negative_format` handling. This keeps Rails callers able to use `number_to_currency` while sourcing `separator` and `delimiter` directly from `money.currency`.

## Verification

Covered by specs for built-in currency attributes, custom currency loading, and NullCurrency interface parity.
