### PR TITLE
Perf: Config.current via direct fiber-local storage (2x faster, fixes fiber-keyed leak)

### DIFF
--- a/lib/money/config.rb
+++ b/lib/money/config.rb
@@ -9,12 +9,14 @@ class Money
         @config ||= new
       end
 
+      # Thread#[] / Thread#[]= are fiber-local in Ruby, which gives us both
+      # per-thread and per-fiber isolation with a single lookup.
       def current
-        thread_local_config[Fiber.current.object_id] ||= global.dup
+        Thread.current[CONFIG_THREAD] ||= global.dup
       end
 
       def current=(config)
-        thread_local_config[Fiber.current.object_id] = config
+        Thread.current[CONFIG_THREAD] = config
       end
 
       def configure_current(**configs, &block)
@@ -30,14 +32,7 @@ class Money
       end
 
       def reset_current
-        thread_local_config.delete(Fiber.current.object_id)
-        Thread.current[CONFIG_THREAD] = nil if thread_local_config.empty?
-      end
-
-      private
-
-      def thread_local_config
-        Thread.current[CONFIG_THREAD] ||= {}
+        Thread.current[CONFIG_THREAD] = nil
       end
     end
 

--- a/sig/money/config.rbs
+++ b/sig/money/config.rbs
@@ -23,8 +23,6 @@ class Money
 
     private
 
-    def self.thread_local_config: () -> Hash[Integer, Config]
-
     def initialize: () -> void
     def legacy_default_currency!: () -> NullCurrency
     def legacy_json_format!: () -> bool


### PR DESCRIPTION
### What

Simplifies `Money::Config.current` by storing the per-fiber config **directly** in fiber-local storage.

`Thread#[]` / `Thread#[]=` are already fiber-local in Ruby, so keeping a hash keyed by `Fiber.current.object_id` *inside* a fiber-local slot was a redundant second layer of fiber isolation. Semantics are identical (per-fiber config, lazily duped from global), with one lookup instead of a fiber-local read + `object_id` call + hash access.

This also removes a subtle leak: entries keyed by dead fibers' `object_id`s could accumulate in the hash until `reset_current` happened to empty it (and `object_id`s can be reused after GC). Fiber-local storage is reclaimed with the fiber automatically.

### Performance

Measured on Ruby 4.0.1 (arm64-darwin), back-to-back on the same machine:

| | main | this PR | Δ |
|---|---|---|---|
| `Config.current` | 102.8 ns/op | 51.0 ns/op | **2.0× faster** |

`Config.current` is on the `Money.new` hot path whenever the currency argument is `nil` (default-currency lookup), and on every `Money.current_currency` / `configure_current` use.

<details>
<summary>Micro-benchmark script (run <code>ruby -Ilib bench_config.rb</code> on each ref)</summary>

```ruby
# frozen_string_literal: true
require "money"

Money.configure { |c| c.default_currency = "USD" }
Money::Config.current # warm

N = 5_000_000
best = 5.times.map do
  t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  i = 0
  while i < N
    Money::Config.current
    i += 1
  end
  Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
end.min
puts format("Config.current: %.1f ns/op", best / N * 1e9)
```

</details>

### Correctness

- Full spec suite (including the fiber/thread isolation specs), rubocop, and steep green; 100% line coverage maintained.
- Note: this intentionally does **not** use the newer `Fiber[]` storage — child fibers inherit `Fiber[]` values, which would be a behavior change.

