### PR TITLE
Perf: Money#positive?/#negative? via BigDecimal#sign (-77% per call, stacked on #532)

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -11,7 +11,15 @@ class Money
 
   attr_reader :value, :currency
 
-  def_delegators :@value, :zero?, :nonzero?, :positive?, :negative?, :to_i, :to_f, :hash
+  # Plain method definitions instead of Forwardable delegators: def_delegators
+  # adds ~30ns of indirection per call to these very hot predicates.
+  def zero? = @value.zero?
+  def nonzero? = @value.nonzero?
+  def positive? = @value.positive?
+  def negative? = @value.negative?
+  def to_i = @value.to_i
+  def to_f = @value.to_f
+  def hash = @value.hash
 
   class ReverseOperationProxy
     include Comparable

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -15,8 +15,13 @@ class Money
   # adds ~30ns of indirection per call to these very hot predicates.
   def zero? = @value.zero?
   def nonzero? = @value.nonzero?
-  def positive? = @value.positive?
-  def negative? = @value.negative?
+  # BigDecimal#sign avoids Numeric#positive?/#negative?, which go through
+  # `self > 0` comparison dispatch and Integer coercion. @value is always
+  # finite (enforced in #initialize), so the sign is one of:
+  #   ±SIGN_POSITIVE_ZERO/SIGN_NEGATIVE_ZERO (±1) for zeros,
+  #   ±SIGN_POSITIVE_FINITE/SIGN_NEGATIVE_FINITE (±2) otherwise.
+  def positive? = @value.sign == BigDecimal::SIGN_POSITIVE_FINITE
+  def negative? = @value.sign == BigDecimal::SIGN_NEGATIVE_FINITE
   def to_i = @value.to_i
   def to_f = @value.to_f
   def hash = @value.hash


### PR DESCRIPTION
### What

Implements `Money#positive?` and `Money#negative?` via `BigDecimal#sign` instead of delegating to `Numeric#positive?`/`#negative?`.

The `Numeric` predicates dispatch through `self > 0`, paying for comparison coercion on every call. `BigDecimal#sign` is a direct C attribute read and is semantically equivalent for Money's domain: `@value` is always finite (enforced in `#initialize`), so `sign` is ±`SIGN_*_ZERO` (±1) for zeros and ±`SIGN_*_FINITE` (±2) for finite nonzero values.

> **Stacked on** #532 (it rewrites the same delegator line, so this branch includes that commit). Review #532 first.

### Performance

Measured on Ruby 4.0.1 (arm64-darwin), 2M calls each, best of 3, vs main:

| method | main | plain defs | + this PR | Δ total |
|---|---|---|---|---|
| `positive?` | 130.5 ns | 98.2 ns | 29.4 ns | **-77%** |
| `negative?` | 128.5 ns | 98.3 ns | 29.4 ns | **-77%** |

`sign` alone is ~3.3× faster than the `Numeric` predicate.

### Correctness

- Verified equivalent across representable values including ±0 and rounding-produced negative zero (e.g. `BigDecimal("-0.001").round(2) => -0.0`, which has `SIGN_NEGATIVE_ZERO` and correctly reports neither positive nor negative).
- Full spec suite, rubocop, and steep green; 100% line coverage maintained.

<details>
<summary>Benchmark script (save as <code>bench.rb</code>, run <code>ruby -Ilib bench.rb</code> on each ref)</summary>

```ruby
# frozen_string_literal: true

# Standalone benchmark for shopify-money hot paths. No external dependencies.
#
# Usage (from the repo root, on each ref you want to compare):
#   ruby -Ilib money_pr_bench.rb
#
# Section 1 measures Money.new across a representative mix of input types
# (median of 7 trials, plus deterministic object allocations per call).
# Section 2 measures a few hot Money instance methods.

require "money"
require "bigdecimal"

Money.configure do |config|
  config.default_currency = "USD"
end

usd = Money::Currency.find!("USD")
big = BigDecimal("12.34")
existing = Money.new(5, "USD")

# Representative input mix (value, currency) — weighted roughly by
# real-world usage: integers/strings/bigdecimals with ISO strings dominate.
INPUTS = [
  [1, "USD"],
  [100, "USD"],
  [42, "CAD"],
  [12.34, "USD"],
  [99.99, "EUR"],
  ["12.34", "USD"],
  ["0.99", "CAD"],
  [big, "USD"],
  [big, usd],
  [1500, "JPY"],
  [0, "USD"],          # zero-cache path
  [existing, "USD"],   # Money passthrough
  [7, nil],            # default currency
  [Rational(1, 3), "USD"],
  ["5", "GBP"],
].freeze

N = 20_000 # iterations of the whole mix per trial

def run_mix
  inputs = INPUTS
  i = 0
  while i < N
    inputs.each { |v, c| Money.new(v, c) }
    i += 1
  end
end

# Warmup (also populates currency cache, zero-money cache, etc.)
2.times { run_mix }

# --- Allocations (deterministic) ---
GC.start
GC.disable
before = GC.stat(:total_allocated_objects)
run_mix
allocs = GC.stat(:total_allocated_objects) - before
GC.enable

total_ops = N * INPUTS.size
allocs_per_op = allocs.to_f / total_ops

# --- Wall time: median of 7 trials ---
times = 7.times.map do
  GC.start
  t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  run_mix
  Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
end
median = times.sort[times.size / 2]
ns_per_op = (median / total_ops) * 1_000_000_000

puts "== Money.new (mixed input types) =="
puts format("  %-18s %8.1f ns/op", "wall time:", ns_per_op)
puts format("  %-18s %8.3f objects/op", "allocations:", allocs_per_op)
puts format("  %-18s %s", "trials (ms):", times.map { |t| (t * 1000).round(1) }.inspect)

# --- Section 2: hot instance methods ---
M = 2_000_000
money = Money.new("12.34", "USD")
neg = Money.new("-12.34", "USD")

def bench_method(label, m)
  best = 3.times.map do
    GC.start
    t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    yield
    Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
  end.min
  puts format("  %-12s %8.1f ns/op", label, (best / m) * 1_000_000_000)
end

puts
puts "== Money instance methods (#{M} calls each, best of 3) =="
bench_method("zero?", M) { i = 0; while i < M; money.zero?; i += 1; end }
bench_method("to_i", M) { i = 0; while i < M; money.to_i; i += 1; end }
bench_method("hash", M) { i = 0; while i < M; money.hash; i += 1; end }
bench_method("positive?", M) { i = 0; while i < M; money.positive?; i += 1; end }
bench_method("negative?", M) { i = 0; while i < M; neg.negative?; i += 1; end }
```

</details>
